### PR TITLE
Rebuild CLI around argparse subcommands

### DIFF
--- a/pydifftools/__init__.py
+++ b/pydifftools/__init__.py
@@ -5,4 +5,5 @@ __all__ = [
     "match_spaces",
     "split_conflict",
     "wrap_sentences",
+    "rearrange_tex",
 ]

--- a/pydifftools/__init__.py
+++ b/pydifftools/__init__.py
@@ -5,4 +5,5 @@ __all__ = [
     "match_spaces",
     "split_conflict",
     "wrap_sentences",
+    "outline",
 ]

--- a/pydifftools/command_line.py
+++ b/pydifftools/command_line.py
@@ -1,4 +1,8 @@
+# PYTHON_ARGCOMPLETE_OK
+
+import argparse
 import sys
+from typing import Callable, Dict, List, Optional, Sequence
 from . import check_numbers, match_spaces, split_conflict, wrap_sentences
 from .separate_comments import tex_sepcomments
 from .unseparate_comments import tex_unsepcomments
@@ -6,6 +10,7 @@ from .comment_functions import matchingbrackets
 from .copy_files import copy_image_files
 from .searchacro import replace_acros
 from .continuous import watch as continuous_watch
+from .rearrange_tex import run as rearrange_tex_run
 import os
 import gzip
 import time
@@ -16,6 +21,35 @@ import nbformat
 import difflib
 import shutil
 from pathlib import Path, PurePosixPath
+
+import argcomplete
+
+
+CommandHandler = Callable[[Sequence[str]], None]
+
+
+class CommandRegistrationError(RuntimeError):
+    """Raised when attempting to register duplicate command handlers."""
+
+
+_COMMAND_SPECS: Dict[str, Dict[str, object]] = {}
+
+
+def register_command(help_text: str, description: Optional[str] = None) -> Callable[[CommandHandler], CommandHandler]:
+    """Register a command handler for the CLI dispatcher."""
+
+    def decorator(func: CommandHandler) -> CommandHandler:
+        name = func.__name__
+        if name in _COMMAND_SPECS:
+            raise CommandRegistrationError(f"Command '{name}' already registered")
+        _COMMAND_SPECS[name] = {
+            "handler": func,
+            "help": help_text.strip(),
+            "description": (description if description is not None else help_text).strip(),
+        }
+        return func
+
+    return decorator
 
 
 def printed_exec(cmd):
@@ -29,9 +63,7 @@ def printed_exec(cmd):
         )
 
 
-def errmsg():
-    print(
-        r"""arguments are:
+CLI_DESCRIPTION = r"""arguments are:
     arxiv   :   make a gzip file suitable for arxiv (currently only test
                 on linux)
     ac      :   look for the file myacronyms.sty (locally or in texmf) and
@@ -69,7 +101,10 @@ def errmsg():
                 lines of a sentence (defaults to 4 -- e.g. for markdown you
                 will always want -i 0)
     xx      :   Convert xml to xlsx"""
-    )
+
+
+def errmsg():
+    print(CLI_DESCRIPTION)
     exit()
 
 
@@ -134,528 +169,654 @@ def look_for_pdf(directory, origbasename):
     return found, basename, actual_name
 
 
-def main():
-    if len(sys.argv) == 1:
-        errmsg()
-    command = sys.argv[1]
-    arguments = sys.argv[2:]
-    if command == "num":
-        check_numbers.run(arguments)
-    elif command == "nb2py":
-        assert arguments[0].endswith(".ipynb"), (
-            "this is supposed to be called with a .ipynb file argument! (arguments are %s)"
-            % repr(arguments)
-        )
-        nb = nbformat.read(arguments[0], nbformat.NO_CONVERT)
-        last_was_markdown = False
-        jupyter_magic_re = re.compile(r"%(.*)")
-        code_counter = 1
-        with open(
-            arguments[0].replace(".ipynb", ".py"), "w", encoding="utf-8"
-        ) as fpout:
-            for j in nb.cells:
-                lines = j["source"].split("\n")
-                if j["cell_type"] == "markdown":
-                    for line in lines:
-                        fpout.write("# " + line + "\n")
-                    if len(lines[-1]) > 0:
-                        # print "markdown, last is",repr(j['source'][-1])
-                        fpout.write("\n")
-                    last_was_markdown = True
-                elif j["cell_type"] == "code":
-                    # fpout.write("start code\n")
-                    if not last_was_markdown:
-                        fpout.write("# In[%d]:\n\n" % code_counter)
-                        code_counter += 1
-                    for line in lines:
-                        m = jupyter_magic_re.match(line)
-                        if m:
-                            fpout.write(
-                                "get_ipython().magic(u'%s')\n" % m.groups()[0]
-                            )
-                        else:
-                            fpout.write(line + "\n")
-                    if len(lines[-1]) > 0:
-                        # print "code, last is",repr(j['source'][-1])
-                        fpout.write("\n")
-                    last_was_markdown = False
-                    # fpout.write("end code\n")
-                else:
-                    raise ValueError("Unknown cell type")
-    elif command == "py2nb":
-        jupyter_magic_re = re.compile(
-            r"^get_ipython\(\).(?:run_line_)?magic\((?:u?['\"]([^'\"]*)['\"])?"
-            + 6 * r"(?:u?, *['\"]([^'\"]*)['\"])?"
-            + r"\)"
-        )
-        jupyter_cellmagic_re = re.compile(
-            r"^get_ipython\(\).run_cell_magic\((?:u?['\"]([^'\"]*)['\"])?"
-            + 6 * r"(?:u?, *['\"]([^'\"]*)['\"])?"
-            + r"\)\)"
-        )
-        assert (
-            len(arguments) == 1
-        ), "py2nb should only be called with one argument"
-        assert arguments[0].endswith(".py"), (
-            "this is supposed to be called with a .py file argument! (arguments are %s)"
-            % repr(arguments)
-        )
-        with open(arguments[0], encoding="utf-8") as fpin:
-            text = fpin.read()
-        text = text.split("\n")
-        newtext = []
-        in_markdown_cell = False
-        in_code_cell = False
-        last_line_empty = True
-        for thisline in text:
-            if thisline.startswith("#"):
-                if thisline.startswith("#!") and "python" in thisline:
-                    pass
-                elif thisline.startswith("# coding: utf-8"):
-                    pass
-                elif thisline.startswith("# In["):
-                    in_code_cell = False
-                    in_markdown_cell = False
-                elif thisline.startswith("# Out["):
-                    pass
-                elif thisline.startswith("# "):
-                    # this is markdown only if the previous line was empty
-                    if last_line_empty:
-                        newtext.append("# <markdowncell>")
-                        in_code_cell = False
-                        in_markdown_cell = True
-                    newtext.append(thisline)
-                last_line_empty = False
-            elif len(thisline) == 0:
-                last_line_empty = True
-                newtext.append(thisline)
+
+@register_command(
+    "check numbers in a latex catalog (e.g. of numbered notebook) of items of the form '\\item[anything number.anything]'"
+)
+def num(arguments):
+    check_numbers.run(arguments)
+
+
+@register_command(
+    "Make a python script from a notebook file, following certain rules."
+)
+def nb2py(arguments):
+    assert arguments[0].endswith(".ipynb"), (
+        "this is supposed to be called with a .ipynb file argument! (arguments are %s)"
+        % repr(arguments)
+    )
+    nb = nbformat.read(arguments[0], nbformat.NO_CONVERT)
+    last_was_markdown = False
+    jupyter_magic_re = re.compile(r"%(.*)")
+    code_counter = 1
+    with open(
+        arguments[0].replace(".ipynb", ".py"), "w", encoding="utf-8"
+    ) as fpout:
+        for j in nb.cells:
+            lines = j["source"].split("\n")
+            if j["cell_type"] == "markdown":
+                for line in lines:
+                    fpout.write("# " + line + "\n")
+                if len(lines[-1]) > 0:
+                    # print "markdown, last is",repr(j['source'][-1])
+                    fpout.write("\n")
+                last_was_markdown = True
+            elif j["cell_type"] == "code":
+                # fpout.write("start code\n")
+                if not last_was_markdown:
+                    fpout.write("# In[%d]:\n\n" % code_counter)
+                    code_counter += 1
+                for line in lines:
+                    m = jupyter_magic_re.match(line)
+                    if m:
+                        fpout.write(
+                            "get_ipython().magic(u'%s')\n" % m.groups()[0]
+                        )
+                    else:
+                        fpout.write(line + "\n")
+                if len(lines[-1]) > 0:
+                    # print "code, last is",repr(j['source'][-1])
+                    fpout.write("\n")
+                last_was_markdown = False
+                # fpout.write("end code\n")
             else:
-                if not in_code_cell:
-                    newtext.append("# <codecell>")
-                    in_code_cell = True
-                    in_markdown_cell = False
-                m = jupyter_magic_re.match(thisline)
+                raise ValueError("Unknown cell type")
+
+
+@register_command(
+    "Make a notebook file from a python script, following certain rules."
+)
+def py2nb(arguments):
+    jupyter_magic_re = re.compile(
+        r"^get_ipython\(\).(?:run_line_)?magic\((?:u?['\"]([^'\"]*)['\"])?"
+        + 6 * r"(?:u?, *['\"]([^'\"]*)['\"])?"
+        + r"\)"
+    )
+    jupyter_cellmagic_re = re.compile(
+        r"^get_ipython\(\).run_cell_magic\((?:u?['\"]([^'\"]*)['\"])?"
+        + 6 * r"(?:u?, *['\"]([^'\"]*)['\"])?"
+        + r"\)\)"
+    )
+    assert (
+        len(arguments) == 1
+    ), "py2nb should only be called with one argument"
+    assert arguments[0].endswith(".py"), (
+        "this is supposed to be called with a .py file argument! (arguments are %s)"
+        % repr(arguments)
+    )
+    with open(arguments[0], encoding="utf-8") as fpin:
+        text = fpin.read()
+    text = text.split("\n")
+    newtext = []
+    in_markdown_cell = False
+    in_code_cell = False
+    last_line_empty = True
+    for thisline in text:
+        if thisline.startswith("#"):
+            if thisline.startswith("#!") and "python" in thisline:
+                pass
+            elif thisline.startswith("# coding: utf-8"):
+                pass
+            elif thisline.startswith("# In["):
+                in_code_cell = False
+                in_markdown_cell = False
+            elif thisline.startswith("# Out["):
+                pass
+            elif thisline.startswith("# "):
+                # this is markdown only if the previous line was empty
+                if last_line_empty:
+                    newtext.append("# <markdowncell>")
+                    in_code_cell = False
+                    in_markdown_cell = True
+                newtext.append(thisline)
+            last_line_empty = False
+        elif len(thisline) == 0:
+            last_line_empty = True
+            newtext.append(thisline)
+        else:
+            if not in_code_cell:
+                newtext.append("# <codecell>")
+                in_code_cell = True
+                in_markdown_cell = False
+            m = jupyter_magic_re.match(thisline)
+            if m:
+                thisline = "%" + " ".join(
+                    (j for j in m.groups() if j is not None)
+                )
+            else:
+                m = jupyter_cellmagic_re.match(thisline)
                 if m:
-                    thisline = "%" + " ".join(
+                    thisline = "%%" + " ".join(
                         (j for j in m.groups() if j is not None)
                     )
-                else:
-                    m = jupyter_cellmagic_re.match(thisline)
-                    if m:
-                        thisline = "%%" + " ".join(
-                            (j for j in m.groups() if j is not None)
-                        )
-                newtext.append(thisline)
-                last_line_empty = False
-        text = "\n".join(newtext)
+            newtext.append(thisline)
+            last_line_empty = False
+    text = "\n".join(newtext)
 
-        text += """
+    text += """
 # <markdowncell>
 # If you can read this, reads_py() is no longer broken! 
 
-        """
+    """
 
-        nbook = nbformat.v3.reads_py(text)
+    nbook = nbformat.v3.reads_py(text)
 
-        nbook = nbformat.v4.upgrade(
-            nbook
-        )  # Upgrade nbformat.v3 to nbformat.v4
-        nbook.metadata.update(
-            {
-                "kernelspec": {
-                    "name": "Python [Anaconda2]",
-                    "display_name": "Python [Anaconda2]",
-                    "language": "python",
-                }
+    nbook = nbformat.v4.upgrade(
+        nbook
+    )  # Upgrade nbformat.v3 to nbformat.v4
+    nbook.metadata.update(
+        {
+            "kernelspec": {
+                "name": "Python [Anaconda2]",
+                "display_name": "Python [Anaconda2]",
+                "language": "python",
             }
-        )
+        }
+    )
 
-        jsonform = nbformat.v4.writes(nbook) + "\n"
-        with open(
-            arguments[0].replace(".py", ".ipynb"), "w", encoding="utf-8"
-        ) as fpout:
-            fpout.write(jsonform)
-    elif command == "gensync":
-        with gzip.open(arguments[0].replace(".pdf", ".synctek.gz")) as fp:
-            orig_synctex = fp.read()
-            fp.close()
-        # since the new synctex is in a new place, I need to tell it
-        # how to get back to the original place
-        relative_path = os.path.relpath(
-            os.path.dir(arguments[0]), os.path.dir(arguments[1])
+    jsonform = nbformat.v4.writes(nbook) + "\n"
+    with open(
+        arguments[0].replace(".py", ".ipynb"), "w", encoding="utf-8"
+    ) as fpout:
+        fpout.write(jsonform)
+
+
+@register_command(
+    "use a compiled latex original (first arg) to generate a synctex file for a scanned document (second arg), e.g.  with handwritten markup"
+)
+def gensync(arguments):
+    with gzip.open(arguments[0].replace(".pdf", ".synctek.gz")) as fp:
+        orig_synctex = fp.read()
+        fp.close()
+    # since the new synctex is in a new place, I need to tell it
+    # how to get back to the original place
+    relative_path = os.path.relpath(
+        os.path.dir(arguments[0]), os.path.dir(arguments[1])
+    )
+    base_fname = arguments[0].replace(".pdf", "")
+    new_synctex = orig_synctex.replace(
+        base_fname, relative_path + base_fname
+    )
+    new_synctex = orig_synctex
+    with gzip.open(arguments[1].replace(".pdf", ".synctek.gz")) as fp:
+        fp.write(new_synctex)
+        fp.write(argument[1].replace())
+        fp.close()
+
+
+@register_command("continuous pandoc build.  Like latexmk, but for markdown!")
+def cpb(arguments):
+    assert len(arguments) == 1
+    continuous_watch(arguments[0])
+
+
+@register_command("rearrange TeX file based on a .rrng plan")
+def rrng(arguments):
+    rearrange_tex_run(arguments)
+
+
+@register_command(
+    "wrap with indented sentence format (for markdown or latex).",
+    (
+        "wrap with indented sentence format (for markdown or latex).\n"
+        "Optional flag --cleanoo cleans latex exported from\n"
+        "OpenOffice/LibreOffice\n"
+        "Optional flag -i # specifies indentation level for subsequent\n"
+        "lines of a sentence (defaults to 4 -- e.g. for markdown you\n"
+        "will always want -i 0)"
+    ),
+)
+def wr(arguments):
+    logging.debug("arguments are", arguments)
+    kwargs = {}
+    if "-i" in arguments:
+        idx = arguments.index("-i")
+        arguments.pop(idx)
+        kwargs["indent_amount"] = int(arguments.pop(idx))
+    if len(arguments) == 1:
+        filename = arguments[0]
+    elif len(arguments) == 2 and arguments[0] == "--cleanoo":
+        filename = arguments[1]
+        kwargs.update({"stupid_strip": True})
+        logging.debug("stripped stupid markup from LibreOffice")
+    elif len(arguments) == 0:
+        filename = None  # wrap_sentences.run(None) # assumes stdin
+    else:
+        raise ValueError(
+            "I don't understand your arguments:" + repr(arguments)
         )
-        base_fname = arguments[0].replace(".pdf", "")
-        new_synctex = orig_synctex.replace(
-            base_fname, relative_path + base_fname
+    # if filename is a markdown file, then set indent_amount to 0
+    if filename is not None and filename[-3:] == ".md":
+        kwargs["indent_amount"] = 0
+    wrap_sentences.run(filename, **kwargs)
+
+
+@register_command(
+    "git forward search, with arguments",
+    "git forward search, with arguments\n\n- file\n- line",
+)
+def gvr(arguments):
+    cmd = ["gvim"]
+    cmd.append("--remote-wait-silent")
+    cmd.append("+" + arguments[1])
+    cmd.append(arguments[0])
+    subprocess.Popen(" ".join(cmd))  # this is forked
+    time.sleep(0.3)
+    cmd = ["gvim"]
+    cmd.append("--remote-send")
+    cmd.append('"zO"')
+    time.sleep(0.3)
+    cmd = ["gvim"]
+    cmd.append("--remote-send")
+    cmd.append('":cd %:h\n"')
+    subprocess.Popen(" ".join(cmd))
+
+
+@register_command("match whitespace")
+def wmatch(arguments):
+    match_spaces.run(arguments)
+
+
+@register_command("split conflict")
+def sc(arguments):
+    split_conflict.run(arguments)
+
+
+@register_command("word diff")
+def wd(arguments):
+    if arguments[0].find("Temp") > 0:
+        # {{{ if it's a temporary file, I need to make a real copy to run pandoc on
+        fp = open(arguments[0], encoding="utf-8")
+        contents = fp.read()
+        fp.close()
+        fp = open(
+            arguments[1].replace(".md", "_old.md"), "w", encoding="utf-8"
         )
-        new_synctex = orig_synctex
-        with gzip.open(arguments[1].replace(".pdf", ".synctek.gz")) as fp:
-            fp.write(new_synctex)
-            fp.write(argument[1].replace())
-            fp.close()
-    elif command == "cpb":
-        assert len(arguments) == 1
-        continuous_watch(arguments[0])
-    elif command == "wr":
-        logging.debug("arguments are", arguments)
-        kwargs = {}
-        if "-i" in arguments:
-            idx = arguments.index("-i")
-            arguments.pop(idx)
-            kwargs["indent_amount"] = int(arguments.pop(idx))
-        if len(arguments) == 1:
-            filename = arguments[0]
-        elif len(arguments) == 2 and arguments[0] == "--cleanoo":
-            filename = arguments[1]
-            kwargs.update({"stupid_strip": True})
-            logging.debug("stripped stupid markup from LibreOffice")
-        elif len(arguments) == 0:
-            filename = None  # wrap_sentences.run(None) # assumes stdin
-        else:
-            raise ValueError(
-                "I don't understand your arguments:" + repr(arguments)
-            )
-        # if filename is a markdown file, then set indent_amount to 0
-        if filename is not None and filename[-3:] == ".md":
-            kwargs["indent_amount"] = 0
-        wrap_sentences.run(filename, **kwargs)
-    elif command == "gvr":
-        cmd = ["gvim"]
-        cmd.append("--remote-wait-silent")
-        cmd.append("+" + arguments[1])
-        cmd.append(arguments[0])
-        subprocess.Popen(" ".join(cmd))  # this is forked
-        time.sleep(0.3)
-        cmd = ["gvim"]
-        cmd.append("--remote-send")
-        cmd.append('"zO"')
-        time.sleep(0.3)
-        cmd = ["gvim"]
-        cmd.append("--remote-send")
-        cmd.append('":cd %:h\n"')
-        subprocess.Popen(" ".join(cmd))
-    elif command == "wmatch":
-        match_spaces.run(arguments)
-    elif command == "sc":
-        split_conflict.run(arguments)
-    elif command == "wd":
-        if arguments[0].find("Temp") > 0:
-            # {{{ if it's a temporary file, I need to make a real copy to run pandoc on
-            fp = open(arguments[0], encoding="utf-8")
-            contents = fp.read()
-            fp.close()
-            fp = open(
-                arguments[1].replace(".md", "_old.md"), "w", encoding="utf-8"
-            )
-            fp.write(contents)
-            fp.close()
-            arguments[0] = arguments[1].replace(".md", "_old.md")
-            # }}}
-        word_files = [x.replace(".md", ".docx") for x in arguments[:2]]
-        local_dir = os.path.dirname(arguments[1])
-        print("local directory:", local_dir)
-        for j in range(2):
-            if arguments[0][-5:] == ".docx":
-                print(
-                    "the first argument has a docx extension, so I'm bypassing the pandoc step"
-                )
-            else:
-                cmd = ["pandoc"]
-                cmd += [arguments[j]]
-                cmd += ["--csl=edited-pmid-format.csl"]
-                cmd += ["--bibliography library_abbrev_utf8.bib"]
-                cmd += ["-s --smart"]
-                if len(arguments) > 2:
-                    if arguments[2][-5:] == ".docx":
-                        cmd += ["--reference-docx=" + arguments[2]]
-                    else:
-                        raise RuntimeError(
-                            "if you pass three arguments to wd, then the third must be a template for the word document"
-                        )
-                elif os.path.isfile(local_dir + os.path.sep + "template.docx"):
-                    # by default, use template.docx in the current directory
-                    cmd += [
-                        "--reference-docx="
-                        + local_dir
-                        + os.path.sep
-                        + "template.docx"
-                    ]
-                cmd += ["-o"]
-                cmd += [word_files[j]]
-                print("about to run", " ".join(cmd))
-                os.system(" ".join(cmd))
-        cmd = ["start"]
-        cmd += [get_data("diff-doc.js")]
-        print("word files are", word_files)
-        if word_files[0].find("C:") > -1:
-            cmd += [word_files[0]]
-        else:
-            cmd += [os.getcwd() + os.path.sep + word_files[0]]
-        cmd += [os.getcwd() + os.path.sep + word_files[1]]
-        print("about to run", " ".join(cmd))
-        os.system(" ".join(cmd))
-    elif command == "rs":
-        cmd = [
-            "gvim",
-            "--servername",
-            "GVIM",
-            "--remote",
-            f"+{arguments[0]} {arguments[1]}",
-        ]
-        os.system(" ".join(cmd))
-        cmd = ["wmctrl", "-a", "GVIM"]
-        os.system(" ".join(cmd))
-        time.sleep(0.5)
-        cmd = ["gvim", "--remote-send", "'<esc>zO:cd %:h'<enter>"]
-        os.system(" ".join(cmd))
-    elif command == "fs":
-        texfile, lineno = arguments
-        texfile = os.path.normpath(os.path.abspath(texfile))
-        directory, texfile = texfile.rsplit(os.path.sep, 1)
-        assert texfile[-4:] == ".tex", "needs to be called .tex"
-        origbasename = texfile[:-4]
-        if os.name == "posix":
-            # linux
-            cmd = ["zathura --synctex-forward"]
-            assert shutil.which("zathura"), (
-                "first, install zathura, then set ~/.config/zathura/zathurarc"
-                "to include"
-                'set synctex-editor-command "pydifft rs %{line} %{input}"'
+        fp.write(contents)
+        fp.close()
+        arguments[0] = arguments[1].replace(".md", "_old.md")
+        # }}}
+    word_files = [x.replace(".md", ".docx") for x in arguments[:2]]
+    local_dir = os.path.dirname(arguments[1])
+    print("local directory:", local_dir)
+    for j in range(2):
+        if arguments[0][-5:] == ".docx":
+            print(
+                "the first argument has a docx extension, so I'm bypassing the pandoc step"
             )
         else:
-            # windows
-            cmd = ["start sumatrapdf -reuse-instance"]
-        if os.path.exists(os.path.join(directory, origbasename + ".pdf")):
-            cmd.append(
-                f"{lineno}:0:{texfile} {os.path.join(directory,origbasename+'.pdf')}"
-            )
-            tex_name = origbasename
-        else:
-            print("no pdf file for this guy, looking for one that has one")
-            found, basename, tex_name = look_for_pdf(directory, origbasename)
-            orig_directory = directory
-            if not found:
-                while (
-                    os.path.sep in directory and directory.lower()[-1] != ":"
-                ):
-                    build_nb = os.path.join(directory, "build_nb")
-                    directory, _ = directory.rsplit(os.path.sep, 1)
-                    if os.path.exists(build_nb):
-                        print("looking for a build_nb subdirectory")
-                        found, basename, tex_name = look_for_pdf(
-                            build_nb, origbasename
-                        )
-                        if found:
-                            directory = build_nb
-                            break
-                    print("looking one directory up, in ", directory)
+            cmd = ["pandoc"]
+            cmd += [arguments[j]]
+            cmd += ["--csl=edited-pmid-format.csl"]
+            cmd += ["--bibliography library_abbrev_utf8.bib"]
+            cmd += ["-s --smart"]
+            if len(arguments) > 2:
+                if arguments[2][-5:] == ".docx":
+                    cmd += ["--reference-docx=" + arguments[2]]
+                else:
+                    raise RuntimeError(
+                        "if you pass three arguments to wd, then the third must be a template for the word document"
+                    )
+            elif os.path.isfile(local_dir + os.path.sep + "template.docx"):
+                # by default, use template.docx in the current directory
+                cmd += [
+                    "--reference-docx="
+                    + local_dir
+                    + os.path.sep
+                    + "template.docx"
+                ]
+            cmd += ["-o"]
+            cmd += [word_files[j]]
+            print("about to run", " ".join(cmd))
+            os.system(" ".join(cmd))
+    cmd = ["start"]
+    cmd += [get_data("diff-doc.js")]
+    print("word files are", word_files)
+    if word_files[0].find("C:") > -1:
+        cmd += [word_files[0]]
+    else:
+        cmd += [os.getcwd() + os.path.sep + word_files[0]]
+    cmd += [os.getcwd() + os.path.sep + word_files[1]]
+    print("about to run", " ".join(cmd))
+    os.system(" ".join(cmd))
+
+
+@register_command("Reverse search")
+def rs(arguments):
+    cmd = [
+        "gvim",
+        "--servername",
+        "GVIM",
+        "--remote",
+        f"+{arguments[0]} {arguments[1]}",
+    ]
+    os.system(" ".join(cmd))
+    cmd = ["wmctrl", "-a", "GVIM"]
+    os.system(" ".join(cmd))
+    time.sleep(0.5)
+    cmd = ["gvim", "--remote-send", "'<esc>zO:cd %:h'<enter>"]
+    os.system(" ".join(cmd))
+
+
+@register_command(
+    "smart latex forward-search",
+    (
+        "smart latex forward-search\n"
+        "currently this works specifically for sumatra pdf located\n"
+        'at "C:\\Program Files\\SumatraPDF\\SumatraPDF.exe",\n'
+        "but can easily be adapted based on os, etc.\n"
+        "Add the following line (or something like it) to your vimrc:\n"
+        "map <c-F>s :cd %:h\\|sil !pydifft fs %:p <c-r>=line(\".\")<cr><cr>\n"
+        "it will map Cntrl-F s to a forward search."
+    ),
+)
+def fs(arguments):
+    texfile, lineno = arguments
+    texfile = os.path.normpath(os.path.abspath(texfile))
+    directory, texfile = texfile.rsplit(os.path.sep, 1)
+    assert texfile[-4:] == ".tex", "needs to be called .tex"
+    origbasename = texfile[:-4]
+    if os.name == "posix":
+        # linux
+        cmd = ["zathura --synctex-forward"]
+        assert shutil.which("zathura"), (
+            "first, install zathura, then set ~/.config/zathura/zathurarc"
+            "to include"
+            'set synctex-editor-command "pydifft rs %{line} %{input}"'
+        )
+    else:
+        # windows
+        cmd = ["start sumatrapdf -reuse-instance"]
+    if os.path.exists(os.path.join(directory, origbasename + ".pdf")):
+        cmd.append(
+            f"{lineno}:0:{texfile} {os.path.join(directory,origbasename+'.pdf')}"
+        )
+        tex_name = origbasename
+    else:
+        print("no pdf file for this guy, looking for one that has one")
+        found, basename, tex_name = look_for_pdf(directory, origbasename)
+        orig_directory = directory
+        if not found:
+            while (
+                os.path.sep in directory and directory.lower()[-1] != ":"
+            ):
+                build_nb = os.path.join(directory, "build_nb")
+                directory, _ = directory.rsplit(os.path.sep, 1)
+                if os.path.exists(build_nb):
+                    print("looking for a build_nb subdirectory")
                     found, basename, tex_name = look_for_pdf(
-                        directory, origbasename
+                        build_nb, origbasename
                     )
                     if found:
+                        directory = build_nb
                         break
-            if not found:
-                raise IOError("This is not the PDF you are looking for!!!")
-            print(
-                "result:", directory, origbasename, found, basename, tex_name
-            )
-            # file has been found, so add to the command
-            cmd.append(
-                f"{lineno}:0:{tex_name}.tex {os.path.join(directory,basename+'.pdf')}"
-            )
-        if os.name == "posix":
-            cmd.append("&")
-        else:
-            cmd.append("-forward-search")
-            cmd.append(tex_name + ".tex")
-            cmd.append("%s -fwdsearch-color ff0000" % lineno)
-        print("changing to directory", directory)
-        os.chdir(directory)
-        print("about to execute:\n\t", " ".join(cmd))
-        os.system(" ".join(cmd))
-        if os.name == "posix":
-            cmd = ["wmctrl", "-a", basename + ".pdf"]
-            os.system(" ".join(cmd))
-    elif command == "xx":
-        format_codes = {
-            "csv": 6,
-            "xlsx": 51,
-            "xml": 46,
-        }  # determined by microsoft vbs
-        cmd = ["start"]
-        cmd += [get_data("xml2xlsx.vbs")]
-        first_ext = arguments[0].split(".")[-1]
-        second_ext = arguments[1].split(".")[-1]
-        for j in arguments[0:2]:
-            if j.find("C:") > -1:
-                cmd += [j]
-            else:
-                cmd += [os.getcwd() + os.path.sep + j]
-        cmd += [str(format_codes[j]) for j in [first_ext, second_ext]]
-        print("about to run", " ".join(cmd))
-        os.system(" ".join(cmd))
-    elif command == "cmp":
-        target = arguments[0]
-        arguments = arguments[1:]
-        with open(target, encoding="utf-8") as fp:
-            base_txt = fp.read()
-        retval = {}
-        for j in arguments:
-            with open(j, encoding="utf-8") as fp:
-                retval[j] = difflib.SequenceMatcher(
-                    None, base_txt, fp.read()
-                ).ratio()
-        print(
-            "\n".join(
-                str(v) + "-->" + str(k)
-                for k, v in sorted(
-                    retval.items(), key=lambda item: item[1], reverse=True
+                print("looking one directory up, in ", directory)
+                found, basename, tex_name = look_for_pdf(
+                    directory, origbasename
                 )
-            )
+                if found:
+                    break
+        if not found:
+            raise IOError("This is not the PDF you are looking for!!!")
+        print(
+            "result:", directory, origbasename, found, basename, tex_name
         )
-    elif command == "sepc":
-        tex_sepcomments(arguments[0])
-    elif command == "unsepc":
-        tex_unsepcomments(arguments[0])
-    elif command == "tex2docx":
-        filename = arguments[0]
-        assert filename[-4:] == ".tex"
-        basename = filename[:-4]
-        with open("%s.tex" % basename, "r", encoding="utf-8") as fp:
-            content = fp.read()
-        comment_re = re.compile(r"\\pdfcomment([A-Z]+)\b")
-        thismatch = comment_re.search(
-            content
-        )  # match doesn't work with newlines, apparently
-        while thismatch:
-            a = thismatch.start()
-            b, c = matchingbrackets(content, a, "{")
-            content = (
-                content[:a]
-                + content[a + 1 : b]
-                + "("
-                + content[b + 1 : c]
-                + ")"
-                + content[c + 1 :]
-            )
-            thismatch = comment_re.search(content)
-        with open(
-            "%s_parencomments.tex" % basename, "w", encoding="utf-8"
-        ) as fp:
-            fp.write(r"\renewcommand{\nts}[1]{\textbf{\textit{#1}}}" + "\n")
-            fp.write(content)
-        printed_exec(
-            "pandoc %s_parencomments.tex -f latex+latex_macros -o %s.md"
-            % ((basename,) * 2)
+        # file has been found, so add to the command
+        cmd.append(
+            f"{lineno}:0:{tex_name}.tex {os.path.join(directory,basename+'.pdf')}"
         )
-        with open("%s.md" % basename, "r", encoding="utf-8") as fp:
-            content = fp.read()
-        thisid = 2
-        comment_re = re.compile(r"pdfcomment([A-Z]+)\(")
-        thismatch = comment_re.search(
-            content
-        )  # match doesn't work with newlines, apparently
-        while thismatch:
-            a = thismatch.start()
-            b, c = matchingbrackets(content, a, "(")
-            author = thismatch.groups()[0]
-            content = (
-                content[:a]
-                + '[%s]{.comment-start id="%d" author="%s"}'
-                % (content[b + 1 : c], thisid, author)
-                + '[]{.comment-end id="%d"}' % thisid
-                + content[c + 1 :]
-            )
-            thisid += 1
-            thismatch = comment_re.search(content)
-        with open("%s.md" % basename, "w", encoding="utf-8") as fp:
-            fp.write(content)
-        printed_exec("pandoc %s.md -o %s.docx" % ((basename,) * 2))
-        printed_exec("start %s.docx" % (basename))
-    elif command == "docx2tex":
-        filename = arguments[0]
-        assert filename[-5:] == ".docx"
-        basename = filename[:-5]
-        printed_exec(
-            "pandoc %s.docx --track-changes=all -o %s.md" % ((basename,) * 2)
-        )
-        with open("%s.md" % basename, "r", encoding="utf-8") as fp:
-            content = fp.read()
-        citation_re = re.compile(r"\\\[\\@")
-        thismatch = citation_re.search(
-            content
-        )  # match doesn't work with newlines, apparently
-        while thismatch:
-            a, b = matchingbrackets(content, thismatch.start(), "[")
-            content = (
-                content[: a - 1] + content[a:b].replace("\\", "") + content[b:]
-            )
-            thismatch = citation_re.search(content)
-        with open("%s.md" % basename, "w", encoding="utf-8") as fp:
-            fp.write(content)
-        printed_exec(
-            "pandoc %s.md --biblatex -r markdown-auto_identifiers -o %s_reconv.tex"
-            % ((basename,) * 2)
-        )
-        print("about to match spaces:")
-        match_spaces.run((basename + ".tex", basename + "_reconv.tex"))
-        with open("%s_reconv.tex" % basename, "r", encoding="utf-8") as fp:
-            content = fp.read()
-        citation_re = re.compile(r"\\autocite\b")
-        content = citation_re.sub(r"\\cite", content)
-        paragraph_re = re.compile(r"\n\n(\\paragraph{.*)\n\n")
-        content = paragraph_re.sub(r"\1", content)
-        # {{{ convert \( to dollars
-        math_re = re.compile(r"\\\(")
-        thismatch = math_re.search(
-            content
-        )  # match doesn't work with newlines, apparently
-        while thismatch:
-            a = thismatch.start()
-            b, c = matchingbrackets(content, a, "(")
-            content = (
-                content[:a] + "$" + content[a + 1 : b] + "$" + content[c + 1 :]
-            )
-            thismatch = math_re.search(content)
-        # }}}
-        with open("%s_reconv.tex" % basename, "w", encoding="utf-8") as fp:
-            fp.write(content)
-    elif command == "arxiv":
-        ROOT_TEX = arguments[0].strip(".tex")
-        project_name = Path.cwd().name
-        TARGET_DIR = Path(f"../{project_name}_forarxiv/")
-        include_suppinfo = False
-        copy_image_files(ROOT_TEX, project_name, TARGET_DIR, include_suppinfo)
-        os.chdir(Path.cwd().parent)
-        output_filename = f"{project_name}_forarxiv.tgz"
-        # create tar process
-        tar = subprocess.Popen(
-            ["tar", "cf", "-", TARGET_DIR.name], stdout=subprocess.PIPE
-        )
-        # create gzip process, using tar's stdout as its stdin
-        gzip = subprocess.Popen(
-            ["gzip", "-9"], stdin=tar.stdout, stdout=subprocess.PIPE
-        )
-        # close tar's stdout so it doesn't hang around waiting for input
-        tar.stdout.close()
-        # write gzip's stdout to a file
-        with open(output_filename, "wb") as fp:
-            shutil.copyfileobj(gzip.stdout, fp)
-        gzip.stdout.close()
-    elif command == "ac":
-        # Run kpsewhich and capture the output
-        kpsewhich_output = subprocess.run(
-            ["kpsewhich", "myacronyms.sty"], capture_output=True, text=True
-        )
-
-        # Convert the string to a pathlib Path object if the file was found, else assign None
-        path = (
-            Path(kpsewhich_output.stdout.strip())
-            if kpsewhich_output.returncode == 0
-            else None
-        )
-        print("I'm using the acronyms in", path)
-        replace_acros(path)
+    if os.name == "posix":
+        cmd.append("&")
     else:
-        errmsg()
-    return
+        cmd.append("-forward-search")
+        cmd.append(tex_name + ".tex")
+        cmd.append("%s -fwdsearch-color ff0000" % lineno)
+    print("changing to directory", directory)
+    os.chdir(directory)
+    print("about to execute:\n\t", " ".join(cmd))
+    os.system(" ".join(cmd))
+    if os.name == "posix":
+        cmd = ["wmctrl", "-a", basename + ".pdf"]
+        os.system(" ".join(cmd))
+
+
+@register_command("Convert xml to xlsx")
+def xx(arguments):
+    format_codes = {
+        "csv": 6,
+        "xlsx": 51,
+        "xml": 46,
+    }  # determined by microsoft vbs
+    cmd = ["start"]
+    cmd += [get_data("xml2xlsx.vbs")]
+    first_ext = arguments[0].split(".")[-1]
+    second_ext = arguments[1].split(".")[-1]
+    for j in arguments[0:2]:
+        if j.find("C:") > -1:
+            cmd += [j]
+        else:
+            cmd += [os.getcwd() + os.path.sep + j]
+    cmd += [str(format_codes[j]) for j in [first_ext, second_ext]]
+    print("about to run", " ".join(cmd))
+    os.system(" ".join(cmd))
+
+
+@register_command("compare files, and rank by how well they compare")
+def cmp(arguments):
+    target = arguments[0]
+    arguments = arguments[1:]
+    with open(target, encoding="utf-8") as fp:
+        base_txt = fp.read()
+    retval = {}
+    for j in arguments:
+        with open(j, encoding="utf-8") as fp:
+            retval[j] = difflib.SequenceMatcher(
+                None, base_txt, fp.read()
+            ).ratio()
+    print(
+        "\n".join(
+            str(v) + "-->" + str(k)
+            for k, v in sorted(
+                retval.items(), key=lambda item: item[1], reverse=True
+            )
+        )
+    )
+
+
+@register_command("tex separate comments")
+def sepc(arguments):
+    tex_sepcomments(arguments[0])
+
+
+@register_command("tex unseparate comments")
+def unsepc(arguments):
+    tex_unsepcomments(arguments[0])
+
+
+@register_command("convert annotated TeX sources to DOCX via pandoc")
+def tex2docx(arguments):
+    filename = arguments[0]
+    assert filename[-4:] == ".tex"
+    basename = filename[:-4]
+    with open("%s.tex" % basename, "r", encoding="utf-8") as fp:
+        content = fp.read()
+    comment_re = re.compile(r"\\pdfcomment([A-Z]+)\b")
+    thismatch = comment_re.search(
+        content
+    )  # match doesn't work with newlines, apparently
+    while thismatch:
+        a = thismatch.start()
+        b, c = matchingbrackets(content, a, "{")
+        content = (
+            content[:a]
+            + content[a + 1 : b]
+            + "("
+            + content[b + 1 : c]
+            + ")"
+            + content[c + 1 :]
+        )
+        thismatch = comment_re.search(content)
+    with open(
+        "%s_parencomments.tex" % basename, "w", encoding="utf-8"
+    ) as fp:
+        fp.write(r"\renewcommand{\nts}[1]{\textbf{\textit{#1}}}" + "\n")
+        fp.write(content)
+    printed_exec(
+        "pandoc %s_parencomments.tex -f latex+latex_macros -o %s.md"
+        % ((basename,) * 2)
+    )
+    with open("%s.md" % basename, "r", encoding="utf-8") as fp:
+        content = fp.read()
+    thisid = 2
+    comment_re = re.compile(r"pdfcomment([A-Z]+)\(")
+    thismatch = comment_re.search(
+        content
+    )  # match doesn't work with newlines, apparently
+    while thismatch:
+        a = thismatch.start()
+        b, c = matchingbrackets(content, a, "(")
+        author = thismatch.groups()[0]
+        content = (
+            content[:a]
+            + '[%s]{.comment-start id="%d" author="%s"}'
+            % (content[b + 1 : c], thisid, author)
+            + '[]{.comment-end id="%d"}' % thisid
+            + content[c + 1 :]
+        )
+        thisid += 1
+        thismatch = comment_re.search(content)
+    with open("%s.md" % basename, "w", encoding="utf-8") as fp:
+        fp.write(content)
+    printed_exec("pandoc %s.md -o %s.docx" % ((basename,) * 2))
+    printed_exec("start %s.docx" % (basename))
+
+
+@register_command("convert DOCX documents back to TeX while cleaning markup")
+def docx2tex(arguments):
+    filename = arguments[0]
+    assert filename[-5:] == ".docx"
+    basename = filename[:-5]
+    printed_exec(
+        "pandoc %s.docx --track-changes=all -o %s.md" % ((basename,) * 2)
+    )
+    with open("%s.md" % basename, "r", encoding="utf-8") as fp:
+        content = fp.read()
+    citation_re = re.compile(r"\\\[\\@")
+    thismatch = citation_re.search(
+        content
+    )  # match doesn't work with newlines, apparently
+    while thismatch:
+        a, b = matchingbrackets(content, thismatch.start(), "[")
+        content = (
+            content[: a - 1] + content[a:b].replace("\\", "") + content[b:]
+        )
+        thismatch = citation_re.search(content)
+    with open("%s.md" % basename, "w", encoding="utf-8") as fp:
+        fp.write(content)
+    printed_exec(
+        "pandoc %s.md --biblatex -r markdown-auto_identifiers -o %s_reconv.tex"
+        % ((basename,) * 2)
+    )
+    print("about to match spaces:")
+    match_spaces.run((basename + ".tex", basename + "_reconv.tex"))
+    with open("%s_reconv.tex" % basename, "r", encoding="utf-8") as fp:
+        content = fp.read()
+    citation_re = re.compile(r"\\autocite\b")
+    content = citation_re.sub(r"\\cite", content)
+    paragraph_re = re.compile(r"\n\n(\\paragraph{.*)\n\n")
+    content = paragraph_re.sub(r"\1", content)
+    # {{{ convert \( to dollars
+    math_re = re.compile(r"\\\(")
+    thismatch = math_re.search(
+        content
+    )  # match doesn't work with newlines, apparently
+    while thismatch:
+        a = thismatch.start()
+        b, c = matchingbrackets(content, a, "(")
+        content = (
+            content[:a] + "$" + content[a + 1 : b] + "$" + content[c + 1 :]
+        )
+        thismatch = math_re.search(content)
+    # }}}
+    with open("%s_reconv.tex" % basename, "w", encoding="utf-8") as fp:
+        fp.write(content)
+
+
+@register_command(
+    "make a gzip file suitable for arxiv (currently only test on linux)"
+)
+def arxiv(arguments):
+    ROOT_TEX = arguments[0].strip(".tex")
+    project_name = Path.cwd().name
+    TARGET_DIR = Path(f"../{project_name}_forarxiv/")
+    include_suppinfo = False
+    copy_image_files(ROOT_TEX, project_name, TARGET_DIR, include_suppinfo)
+    os.chdir(Path.cwd().parent)
+    output_filename = f"{project_name}_forarxiv.tgz"
+    # create tar process
+    tar = subprocess.Popen(
+        ["tar", "cf", "-", TARGET_DIR.name], stdout=subprocess.PIPE
+    )
+    # create gzip process, using tar's stdout as its stdin
+    gzip = subprocess.Popen(
+        ["gzip", "-9"], stdin=tar.stdout, stdout=subprocess.PIPE
+    )
+    # close tar's stdout so it doesn't hang around waiting for input
+    tar.stdout.close()
+    # write gzip's stdout to a file
+    with open(output_filename, "wb") as fp:
+        shutil.copyfileobj(gzip.stdout, fp)
+    gzip.stdout.close()
+
+
+@register_command(
+    "look for the file myacronyms.sty (locally or in texmf) and use it substitute your acronyms"
+)
+def ac(arguments):
+    # Run kpsewhich and capture the output
+    kpsewhich_output = subprocess.run(
+        ["kpsewhich", "myacronyms.sty"], capture_output=True, text=True
+    )
+
+    # Convert the string to a pathlib Path object if the file was found, else assign None
+    path = (
+        Path(kpsewhich_output.stdout.strip())
+        if kpsewhich_output.returncode == 0
+        else None
+    )
+    print("I'm using the acronyms in", path)
+    replace_acros(path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=CLI_DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.required = True
+    for name, spec in _COMMAND_SPECS.items():
+        subparser = subparsers.add_parser(
+            name,
+            help=spec["help"],
+            description=spec["description"],
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
+        subparser.add_argument("args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+        subparser.set_defaults(_handler=spec["handler"])
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+    parser = build_parser()
+    argcomplete.autocomplete(parser)
+    if not argv:
+        parser.print_help()
+        return
+    namespace = parser.parse_args(argv)
+    handler = namespace._handler
+    arguments = list(namespace.args)
+    handler(arguments)
+

--- a/pydifftools/command_line.py
+++ b/pydifftools/command_line.py
@@ -63,49 +63,10 @@ def printed_exec(cmd):
         )
 
 
-CLI_DESCRIPTION = r"""arguments are:
-    arxiv   :   make a gzip file suitable for arxiv (currently only test
-                on linux)
-    ac      :   look for the file myacronyms.sty (locally or in texmf) and
-                use it substitute your acronyms
-    cpb     :   continuous pandoc build.  Like latexmk, but for markdown!
-    fs      :   smart latex forward-search
-                currently this works specifically for sumatra pdf located
-                at "C:\Program Files\SumatraPDF\SumatraPDF.exe",
-                but can easily be adapted based on os, etc.
-                Add the following line (or something like it) to your vimrc:
-                map <c-F>s :cd %:h\|sil !pydifft fs %:p <c-r>=line(".")<cr><cr>
-                it will map Cntrl-F s to a forward search.
-    rs      :   Reverse search
-    py2nb   :   Make a notebook file from a python script, following certain rules.
-    nb2py   :   Make a python script from a notebook file, following certain rules.
-    num     :   check numbers in a latex catalog (e.g. of numbered notebook)
-                of items of the form '\item[anything number.anything]'
-    gensync :   use a compiled latex original (first arg) to generate a synctex
-                file for a scanned document (second arg), e.g.  with
-                handwritten markup
-    wmatch  :   match whitespace
-    cmp     :   compare files, and rank by how well they compare
-    gvr     :   git forward search, with arguments
-
-                - file
-                - line
-    sc      :   split conflict
-    sepc    :   tex separate comments
-    unsepc  :   tex unseparate comments
-    wd      :   word diff
-    wr      :   wrap with indented sentence format (for markdown or latex).
-                Optional flag --cleanoo cleans latex exported from
-                OpenOffice/LibreOffice
-                Optional flag -i # specifies indentation level for subsequent
-                lines of a sentence (defaults to 4 -- e.g. for markdown you
-                will always want -i 0)
-    xx      :   Convert xml to xlsx"""
-
-
 def errmsg():
-    print(CLI_DESCRIPTION)
-    exit()
+    parser = build_parser()
+    parser.print_help()
+    sys.exit(1)
 
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -789,10 +750,7 @@ def ac(arguments):
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description=CLI_DESCRIPTION,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
+    parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
     subparsers.required = True
     for name, spec in _COMMAND_SPECS.items():

--- a/pydifftools/continuous.py
+++ b/pydifftools/continuous.py
@@ -21,20 +21,24 @@ def run_pandoc(filename, html_file):
         )
         print("and then unzip")
     current_dir = os.getcwd()
-    csl_files = [f for f in os.listdir(current_dir) if f.endswith(".csl")]
-    if len(csl_files) == 1:
-        mycsl = csl_files[0]
-    else:
-        raise ValueError(
-            "You have more than one csl file in this directory! Get rid of all"
-            " but one! of "
-            + "and".join(csl_files)
-        )
+    localfiles = {}
+    for k in ["csl", "bib"]:
+        localfiles[k] = [
+            f for f in os.listdir(current_dir) if f.endswith("." + k)
+        ]
+        if len(localfiles[k]) == 1:
+            localfiles[k] = localfiles[k][0]
+        else:
+            raise ValueError(
+                f"You have more than one (or no) {k} file in this directory!"
+                " Get rid of all but one! of "
+                + "and".join(localfiles[k])
+            )
     command = [
         "pandoc",
         "--bibliography",
-        "references.bib",
-        f"--csl={mycsl}",
+        localfiles["bib"],
+        f"--csl={localfiles['csl']}",
         "--filter",
         "pandoc-crossref",
         "--citeproc",
@@ -50,8 +54,9 @@ def run_pandoc(filename, html_file):
     subprocess.run(
         command,
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stderr=sys.stdout,
     )
+    print("running:\n", command)
     if has_local_jax:
         # {{{ for slow internet connection, remove remote files
         with open(html_file, encoding="utf-8") as fp:

--- a/pydifftools/outline.py
+++ b/pydifftools/outline.py
@@ -1,0 +1,71 @@
+import pickle
+from .doc_contents import doc_contents_class
+import re
+
+
+def extract_outline(filename):
+    basename = filename.replace(".tex", "")
+    section_re = re.compile(
+        r"\\(paragraph|subsubsection|subsection|section)\{"
+    )
+
+    all_contents = doc_contents_class()
+    bracelevel = 0
+    with open(filename, "r", encoding="utf-8") as fp:
+        for thisline in fp:
+            if bracelevel == 0:
+                thismatch = section_re.match(thisline)
+                if thismatch:
+                    sectype = thismatch.groups()[0]
+                    bracelevel = 1
+                    all_contents += thisline[: thismatch.start()]
+                    escaped = False
+                    thistitle = ""
+                else:
+                    all_contents += thisline
+            if (
+                bracelevel > 0
+            ):  # do this whether continued open brace from previous line, or if we opened brace on previous
+                for n, j in enumerate(thisline[thismatch.end() :]):
+                    if escaped:
+                        escaped = False
+                    elif j == "\\":
+                        escaped = True
+                    elif j == "{":
+                        bracelevel += 1
+                    elif j == "}":
+                        bracelevel -= 1
+                    if bracelevel > 0:
+                        thistitle += j
+                    else:
+                        all_contents.start_sec(sectype, thistitle)
+                        all_contents += thisline[thismatch.end() + n + 1 :]
+                        break
+                else:  # hit the end of the line without the break
+                    thisline += "\n"
+    with open(f"{basename}_outline.pickle", "wb") as fp:
+        pickle.dump(all_contents, fp)
+    with open(f"{basename}_outline.md", "w", encoding="utf-8") as fp:
+        fp.write(all_contents.outline)
+
+
+def write_reordered(texfile):
+    markdownfile = texfile.replace(".tex", "_outline.md")
+    picklefile = texfile.replace(".tex", "_outline.pickle")
+    if not (
+        markdownfile.endswith(".md")
+        and picklefile.endswith(".pickle")
+        and texfile.endswith(".tex")
+    ):
+        raise ValueError(
+            "pass arguments markdownfile (input) picklefile (input) texfile"
+            " (output)"
+        )
+
+    with open(picklefile, "rb") as fp:
+        all_contents = pickle.load(fp)
+    with open(markdownfile, "r", encoding="utf-8") as fp:
+        for thisline in fp:
+            all_contents.outline_in_order(thisline.rstrip())
+    with open(texfile, "w", encoding="utf-8", newline="\n") as fp:
+        fp.write(str(all_contents))

--- a/pydifftools/wrap_sentences.py
+++ b/pydifftools/wrap_sentences.py
@@ -62,6 +62,11 @@ def run(
         elif file_extension == "md":
             # print("identified as markdown!!")
             filetype = "markdown"
+        elif file_extension == "qmd":
+            # print("identified as markdown!!")
+            filetype = "markdown"
+        if filetype == "markdown":
+            indent_amount = 0
         # }}}
     else:
         sys.stdin.reconfigure(encoding="utf-8")
@@ -347,31 +352,33 @@ def run(
                                         # print(thispara_split[starting_line : closing_line + 1])
                                         # print("*" * 73)
                                         # }}}
-                                    else:
-                                        m = re.search(
-                                            r"^ *([*\-]|[0-9]+\.) +", thisline
-                                        )  # exclude lists
-                                        if m:
-                                            starting_line = line_idx
-                                            stop_line = line_idx
-                                            while m:
-                                                line_idx += 1
-                                                if line_idx > len(thispara_split)-1:
-                                                    line_idx -= 1
-                                                    stop_line = line_idx
-                                                    break
-                                                testline = thispara_split[line_idx]
-                                                m = re.search(
-                                                        f"^ {{{m.span()[1]-m.span()[0]}}}", testline
-                                                        )
-                                                if m:
-                                                    stop_line = line_idx
-                                                else:
-                                                    line_idx -= 1
-                                                    break
-                                            exclusion_idx.append(
-                                                (para_idx, starting_line, stop_line)
-                                            )
+                                    # following seems to exclude everything
+                                    #else:
+                                    #    m = re.search(
+                                    #        r"^ *([*\-]|[0-9]+\.) +", thisline
+                                    #    )  # exclude lists
+                                    #    if m:
+                                    #        print("bullet",thisline)
+                                    #        starting_line = line_idx
+                                    #        stop_line = line_idx
+                                    #        while m:
+                                    #            line_idx += 1
+                                    #            if line_idx > len(thispara_split)-1:
+                                    #                line_idx -= 1
+                                    #                stop_line = line_idx
+                                    #                break
+                                    #            testline = thispara_split[line_idx]
+                                    #            m = re.search(
+                                    #                    f"^ {{{m.span()[1]-m.span()[0]}}}", testline
+                                    #                    )
+                                    #            if m:
+                                    #                stop_line = line_idx
+                                    #                print("continuation:", testline)
+                                    #            else:
+                                    #                line_idx -= 1
+                                    #        exclusion_idx.append(
+                                    #            (para_idx, starting_line, stop_line)
+                                    #        )
                 line_idx += 1
                 # }}}
     # print("all exclusions:", exclusion_idx)

--- a/tests/test_rrng.py
+++ b/tests/test_rrng.py
@@ -91,6 +91,18 @@ def test_rrng_supports_line_ranges(tmp_path):
     )
 
 
+def test_rrng_allows_spaces_in_substitutions(tmp_path):
+    # Confirm that search and replacement sections may contain spaces without breaking tokenization.
+    tex_path = tmp_path / "spaces.tex"
+    tex_path.write_text("alpha beta\ngamma\n", encoding="utf-8")
+    plan_path = tmp_path / "spaces.rrng"
+    plan_path.write_text("1 s/alpha beta/ALPHA BETA/\n2\n", encoding="utf-8")
+
+    command_line.main(["rrng", str(tex_path), str(plan_path)])
+
+    assert tex_path.read_text(encoding="utf-8") == "ALPHA BETA\ngamma\n"
+
+
 def test_rrng_requires_all_lines(tmp_path):
     # Confirm that missing source lines cause the command to abort with a helpful error message.
     tex_path = tmp_path / "missing.tex"

--- a/tests/test_rrng.py
+++ b/tests/test_rrng.py
@@ -1,0 +1,118 @@
+import itertools
+import sys
+import textwrap
+from pathlib import Path
+from types import ModuleType
+
+# Make sure the repository root is importable so the CLI module can be exercised in place.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide a minimal numpy stub so importing the CLI does not require the real dependency.
+numpy_stub = ModuleType("numpy")
+numpy_stub.array = lambda data: list(data)
+numpy_stub.cumsum = lambda data: list(itertools.accumulate(data))
+numpy_stub.argmin = (
+    lambda data: min(range(len(data)), key=lambda i: abs(data[i])) if data else 0
+)
+sys.modules.setdefault("numpy", numpy_stub)
+
+# Stub out heavyweight optional dependencies referenced by unrelated commands.
+selenium_stub = ModuleType("selenium")
+selenium_stub.webdriver = ModuleType("selenium.webdriver")
+sys.modules.setdefault("selenium", selenium_stub)
+sys.modules.setdefault("selenium.webdriver", selenium_stub.webdriver)
+sys.modules.setdefault("psutil", ModuleType("psutil"))
+watchdog_stub = ModuleType("watchdog")
+watchdog_observers_stub = ModuleType("watchdog.observers")
+watchdog_observers_stub.Observer = object
+watchdog_events_stub = ModuleType("watchdog.events")
+watchdog_events_stub.FileSystemEventHandler = object
+sys.modules.setdefault("watchdog", watchdog_stub)
+sys.modules.setdefault("watchdog.observers", watchdog_observers_stub)
+sys.modules.setdefault("watchdog.events", watchdog_events_stub)
+nbformat_stub = ModuleType("nbformat")
+nbformat_stub.NO_CONVERT = object()
+nbformat_stub.read = lambda *args, **kwargs: None
+sys.modules.setdefault("nbformat", nbformat_stub)
+argcomplete_stub = ModuleType("argcomplete")
+argcomplete_stub.autocomplete = lambda parser: None
+sys.modules.setdefault("argcomplete", argcomplete_stub)
+separate_stub = ModuleType("pydifftools.separate_comments")
+separate_stub.tex_sepcomments = lambda *args, **kwargs: None
+sys.modules.setdefault("pydifftools.separate_comments", separate_stub)
+unseparate_stub = ModuleType("pydifftools.unseparate_comments")
+unseparate_stub.tex_unsepcomments = lambda *args, **kwargs: None
+sys.modules.setdefault("pydifftools.unseparate_comments", unseparate_stub)
+
+import pytest
+
+from pydifftools import command_line
+
+
+def test_rrng_rearranges_tex(tmp_path):
+    # Create a TeX file and rearrangement plan that exercises comments, substitutions, and scratch output.
+    tex_path = tmp_path / "sample.tex"
+    tex_path.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    plan_path = tmp_path / "sample.rrng"
+    plan_path.write_text(
+        textwrap.dedent(
+            """\
+            # Rearrangement Plan
+            1 scratch
+            2 s/a/A/
+            3 s/m/Z/g
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    # Invoke the rrng subcommand through the CLI entry point to exercise the registered handler.
+    command_line.main(["rrng", str(tex_path), str(plan_path)])
+
+    # Verify that the TeX file now contains the rearranged lines with the scratch section appended.
+    assert (
+        tex_path.read_text(encoding="utf-8")
+        == "% Rearrangement Plan\nbetA\ngaZZa\n% --- SCRATCH ---\n% alpha\n"
+    )
+
+
+def test_rrng_requires_all_lines(tmp_path):
+    # Confirm that missing source lines cause the command to abort with a helpful error message.
+    tex_path = tmp_path / "missing.tex"
+    tex_path.write_text("one\ntwo\n", encoding="utf-8")
+    plan_path = tmp_path / "missing.rrng"
+    plan_path.write_text(
+        textwrap.dedent(
+            """
+            1
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        command_line.main(["rrng", str(tex_path), str(plan_path)])
+
+    assert "ERROR: Plan missing lines: [2]" in str(excinfo.value)
+
+
+def test_rrng_rejects_duplicate_lines(tmp_path):
+    # Confirm that duplicate line references surface a clear error so the user fixes the plan file.
+    tex_path = tmp_path / "dupe.tex"
+    tex_path.write_text("red\nblue\n", encoding="utf-8")
+    plan_path = tmp_path / "dupe.rrng"
+    plan_path.write_text(
+        textwrap.dedent(
+            """
+            1
+            1
+            2
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        command_line.main(["rrng", str(tex_path), str(plan_path)])
+
+    assert "ERROR: Plan duplicated lines: [1]" in str(excinfo.value)

--- a/tests/test_rrng.py
+++ b/tests/test_rrng.py
@@ -76,6 +76,21 @@ def test_rrng_rearranges_tex(tmp_path):
     )
 
 
+def test_rrng_supports_line_ranges(tmp_path):
+    # Confirm that a plan line specifying an inclusive range applies to each source line in order.
+    tex_path = tmp_path / "ranges.tex"
+    tex_path.write_text("one\ntwo\nthree\nfour\nfive\n", encoding="utf-8")
+    plan_path = tmp_path / "ranges.rrng"
+    plan_path.write_text("1-2\n5 scratch\n3-4 s/o/O/\n", encoding="utf-8")
+
+    command_line.main(["rrng", str(tex_path), str(plan_path)])
+
+    assert (
+        tex_path.read_text(encoding="utf-8")
+        == "one\ntwo\nthree\nfOur\n% --- SCRATCH ---\n% five\n"
+    )
+
+
 def test_rrng_requires_all_lines(tmp_path):
     # Confirm that missing source lines cause the command to abort with a helpful error message.
     tex_path = tmp_path / "missing.tex"


### PR DESCRIPTION
## Summary
- add a command registration decorator that infers the subcommand name from each function and stores help/description text for argparse
- lift the legacy command handlers into decorated functions without altering their logic and register the new rrng rearrangement helper
- replace the manual CLI dispatch with an argparse subparser tree that plugs into argcomplete for tab completion
- restore command help text literals directly on each decorator for readability and easier maintenance

## Testing
- python -m compileall pydifftools/command_line.py pydifftools/rearrange_tex.py

------
https://chatgpt.com/codex/tasks/task_e_68dea9fe3988832ba3dcefd2e77ff890