### PR TITLE
Fix qmd imports and stdout handling

### DIFF
--- a/pydifftools/command_line.py
+++ b/pydifftools/command_line.py
@@ -119,7 +119,8 @@ def look_for_pdf(directory, origbasename):
 def nb2py(arguments):
     assert arguments[0].endswith(".ipynb"), (
         "this is supposed to be called with a .ipynb file argument! (arguments"
-        " are %s)" % repr(arguments)
+        " are %s)"
+        % repr(arguments)
     )
     nb = nbformat.read(arguments[0], nbformat.NO_CONVERT)
     last_was_markdown = False
@@ -176,7 +177,8 @@ def py2nb(arguments):
     assert len(arguments) == 1, "py2nb should only be called with one argument"
     assert arguments[0].endswith(".py"), (
         "this is supposed to be called with a .py file argument! (arguments"
-        " are %s)" % repr(arguments)
+        " are %s)"
+        % repr(arguments)
     )
     with open(arguments[0], encoding="utf-8") as fpin:
         text = fpin.read()
@@ -232,15 +234,13 @@ def py2nb(arguments):
     nbook = nbformat.v3.reads_py(text)
 
     nbook = nbformat.v4.upgrade(nbook)  # Upgrade nbformat.v3 to nbformat.v4
-    nbook.metadata.update(
-        {
-            "kernelspec": {
-                "name": "Python [Anaconda2]",
-                "display_name": "Python [Anaconda2]",
-                "language": "python",
-            }
+    nbook.metadata.update({
+        "kernelspec": {
+            "name": "Python [Anaconda2]",
+            "display_name": "Python [Anaconda2]",
+            "language": "python",
         }
-    )
+    })
 
     jsonform = nbformat.v4.writes(nbook) + "\n"
     with open(
@@ -731,8 +731,8 @@ def main(argv=None):
     )
     if not already_checked_today:
         os.environ["PYDIFFTOOLS_UPDATE_CHECK_LAST_RAN_UTC_DATE"] = today
-        current_version, latest_version, is_outdated = update_check.check_update(
-            "pyDiffTools"
+        current_version, latest_version, is_outdated = (
+            update_check.check_update("pyDiffTools")
         )
         if is_outdated and latest_version is not None:
             print(

--- a/pydifftools/command_line.py
+++ b/pydifftools/command_line.py
@@ -29,7 +29,6 @@ from .flowchart.watch_graph import wgrph
 from .notebook.tex_to_qmd import tex2qmd
 from .notebook.fast_build import qmdb, qmdinit
 
-
 from .command_registry import _COMMAND_SPECS, register_command
 
 

--- a/pydifftools/continuous.py
+++ b/pydifftools/continuous.py
@@ -99,7 +99,7 @@ class Handler(FileSystemEventHandler):
             self.append_autorefresh()
             try:
                 self.firefox.refresh()
-            except selenium.common.exceptions.WebDriverException:
+            except WebDriverException:
                 print(
                     "I'm quitting!! You probably suspended the computer, which"
                     " seems to freak selenium out.  Just restart"

--- a/pydifftools/flowchart/watch_graph.py
+++ b/pydifftools/flowchart/watch_graph.py
@@ -4,12 +4,6 @@ from pathlib import Path
 from typing import Dict, Any
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from selenium.common.exceptions import (
-    WebDriverException,
-    NoSuchWindowException,
-)
 from pydifftools.command_registry import register_command
 from .graph import write_dot_from_yaml
 
@@ -103,6 +97,21 @@ class GraphEventHandler(FileSystemEventHandler):
     },
 )
 def wgrph(yaml, wrap_width=55):
+    # Selenium is only required when actually launching the watcher, so it is
+    # imported here to avoid breaking the command-line tools when the optional
+    # dependency is not installed.
+    try:
+        from selenium import webdriver
+        from selenium.webdriver.chrome.options import Options
+        from selenium.common.exceptions import (
+            WebDriverException,
+            NoSuchWindowException,
+        )
+    except ImportError as exc:
+        raise ImportError(
+            "The 'watch_graph' command requires the 'selenium' package."
+        ) from exc
+
     yaml_file = Path(yaml)
     if not yaml_file.exists():
         raise FileNotFoundError(f"YAML file not found: {yaml_file}")

--- a/pydifftools/notebook/fast_build.py
+++ b/pydifftools/notebook/fast_build.py
@@ -19,7 +19,10 @@ from pydifftools.command_registry import register_command
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers.polling import PollingObserver as Observer
 from selenium import webdriver
-from selenium.common.exceptions import WebDriverException, NoSuchWindowException
+from selenium.common.exceptions import (
+    WebDriverException,
+    NoSuchWindowException,
+)
 from jinja2 import Environment, FileSystemLoader
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
@@ -1048,9 +1051,9 @@ def substitute_code_placeholders(
         if not missing_output and html:
             frags += lxml_html.fragments_fromstring(html)
         elif missing_output:
-            # Only show the placeholder when the notebook output entry is absent
-            # so executed cells that intentionally produce no output simply
-            # render the source code.
+            # Only show the placeholder when the notebook output entry is
+            # absent so executed cells that intentionally produce no output
+            # simply render the source code.
             waiting = lxml_html.fragment_fromstring(
                 '<div style="color:red;font-weight:bold">'
                 f"Running notebook {src}..."
@@ -1200,14 +1203,12 @@ def build_all(webtex: bool = False, changed_paths=None):
         html_file = (DISPLAY_DIR / qmd).with_suffix(".html")
         if html_file.exists():
             sections = parse_headings(html_file)
-            pages.append(
-                {
-                    "file": qmd,
-                    "href": html_file.name,
-                    "title": read_title(Path(qmd)),
-                    "sections": sections,
-                }
-            )
+            pages.append({
+                "file": qmd,
+                "href": html_file.name,
+                "title": read_title(Path(qmd)),
+                "sections": sections,
+            })
 
     for page in pages:
         html_file = (DISPLAY_DIR / page["file"]).with_suffix(".html")
@@ -1229,7 +1230,8 @@ class BrowserReloader:
     def init_browser(self):
         if webdriver is None:
             raise ImportError(
-                "Browser refresh support requires the optional 'selenium' package."
+                "Browser refresh support requires the optional 'selenium'"
+                " package."
             )
         try:
             self.browser = webdriver.Chrome()

--- a/pydifftools/notebook/fast_build.py
+++ b/pydifftools/notebook/fast_build.py
@@ -17,27 +17,9 @@ import shutil
 import yaml
 from pydifftools.command_registry import register_command
 from watchdog.events import FileSystemEventHandler
-
-# Optional dependencies used for live file watching and browser refreshes are
-# loaded lazily so importing this module does not fail when they are absent.
-try:
-    from watchdog.observers.polling import PollingObserver as Observer
-except Exception:
-    Observer = None
-
-try:
-    from selenium import webdriver
-    from selenium.common import exceptions as selenium_ex
-except Exception:
-    webdriver = None
-    selenium_ex = None
-
-if selenium_ex:
-    WebDriverException = selenium_ex.WebDriverException
-    NoSuchWindowException = selenium_ex.NoSuchWindowException
-else:
-    WebDriverException = None
-    NoSuchWindowException = None
+from watchdog.observers.polling import PollingObserver as Observer
+from selenium import webdriver
+from selenium.common.exceptions import WebDriverException, NoSuchWindowException
 from jinja2 import Environment, FileSystemLoader
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor

--- a/pydifftools/separate_comments.py
+++ b/pydifftools/separate_comments.py
@@ -1,8 +1,4 @@
 import re
-import sys
-import codecs
-
-sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())
 from .comment_functions import (
     generate_alphabetnumber,
     matchingbrackets,

--- a/pydifftools/unseparate_comments.py
+++ b/pydifftools/unseparate_comments.py
@@ -1,8 +1,4 @@
 import re
-import sys
-import codecs
-
-sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())
 from .comment_functions import generate_alphabetnumber, matchingbrackets
 
 

--- a/pydifftools/unseparate_comments.py
+++ b/pydifftools/unseparate_comments.py
@@ -1,5 +1,5 @@
 import re
-from .comment_functions import generate_alphabetnumber, matchingbrackets
+from .comment_functions import matchingbrackets
 
 
 def tex_unsepcomments(texfile):
@@ -45,7 +45,8 @@ def tex_unsepcomments(texfile):
             starthighlight, b = matchingbrackets(content, a, "{")
             highlight = content[starthighlight + 1 : b]
             print(
-                "found command \\%s with highlight {%s} and going to add content {%s}"
+                "found command \\%s with highlight {%s} and going to add"
+                " content {%s}"
                 % (list_of_commands[j], highlight, list_of_content[j])
             )
             if len(highlight) > 0:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1,11 +1,8 @@
-import importlib.util
 import os
 import subprocess
 import sys
 import time
-import types
 from pathlib import Path
-from pydifftools import command_line
 
 
 def _make_cli_env(tmp_path):

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -24,8 +24,7 @@ def _make_cli_env(tmp_path):
         "def argmin(*args, **kwargs):\n    return 0\n"
     )
     (stub_dir / "psutil.py").write_text("pass\n")
-    bib_path = Path("/home/jmfranck/My Library.bib")
-    bib_path.parent.mkdir(parents=True, exist_ok=True)
+    bib_path = Path("~/testlib.bib").expanduser()
     bib_path.write_text("@book{dummy, title={Dummy}}\n")
     pandoc_script = bin_dir / "pandoc"
     pandoc_script.write_text(

--- a/tests/test_tex_to_qmd.py
+++ b/tests/test_tex_to_qmd.py
@@ -1,0 +1,11 @@
+from pydifftools.notebook.tex_to_qmd import format_tags
+
+def test_err_block_ensures_blank_line_after_close():
+    text = "<err>\ninner\n</err>Next section\n"
+    formatted = format_tags(text)
+    assert "</err>\n\nNext section" in formatted
+
+def test_err_block_allows_br_after_close():
+    text = "<err>\ninner\n</err>\n<br/>\n"
+    formatted = format_tags(text)
+    assert "</err>\n\n<br/>" in formatted

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,10 +1,7 @@
-import importlib.util
 import json
 import io
 import os
-import sys
 import time
-import types
 import urllib.error
 
 
@@ -14,7 +11,9 @@ from pydifftools import command_line
 
 def test_check_update_reports_newer_release(monkeypatch):
     # Simulate installed version and a newer one on PyPI.
-    monkeypatch.setattr(update_check.importlib.metadata, "version", lambda name: "1.0.0")
+    monkeypatch.setattr(
+        update_check.importlib.metadata, "version", lambda name: "1.0.0"
+    )
 
     payload = json.dumps({"info": {"version": "2.0.0"}}).encode("utf-8")
 
@@ -30,22 +29,31 @@ def test_check_update_reports_newer_release(monkeypatch):
 
     monkeypatch.setattr(update_check.urllib.request, "urlopen", fake_urlopen)
 
-    current_version, latest_version, is_outdated = update_check.check_update("pyDiffTools")
+    current_version, latest_version, is_outdated = update_check.check_update(
+        "pyDiffTools"
+    )
     assert current_version == "1.0.0"
     assert latest_version == "2.0.0"
     assert is_outdated is True
 
 
 def test_check_update_handles_offline(monkeypatch):
-    # Offline or timeout errors should not raise and should not report an update.
-    monkeypatch.setattr(update_check.importlib.metadata, "version", lambda name: "1.0.0")
+    # Offline or timeout errors should not raise and should not report an
+    # update.
+    monkeypatch.setattr(
+        update_check.importlib.metadata, "version", lambda name: "1.0.0"
+    )
 
     def offline_urlopen(url, timeout=1):
         raise urllib.error.URLError("offline")
 
-    monkeypatch.setattr(update_check.urllib.request, "urlopen", offline_urlopen)
+    monkeypatch.setattr(
+        update_check.urllib.request, "urlopen", offline_urlopen
+    )
 
-    current_version, latest_version, is_outdated = update_check.check_update("pyDiffTools")
+    current_version, latest_version, is_outdated = update_check.check_update(
+        "pyDiffTools"
+    )
     assert current_version == "1.0.0"
     assert latest_version is None
     assert is_outdated is False
@@ -54,7 +62,9 @@ def test_check_update_handles_offline(monkeypatch):
 def test_cli_update_check_runs_once_per_day(monkeypatch):
     # The CLI should only call out to PyPI once per UTC day and should set
     # the env var so subsequent invocations can skip the check.
-    monkeypatch.delenv("PYDIFFTOOLS_UPDATE_CHECK_LAST_RAN_UTC_DATE", raising=False)
+    monkeypatch.delenv(
+        "PYDIFFTOOLS_UPDATE_CHECK_LAST_RAN_UTC_DATE", raising=False
+    )
 
     calls = []
 


### PR DESCRIPTION
## Summary
- import qmd commands directly so required notebook dependencies must be installed
- remove stdout detaching side effects from comment utilities to keep pytest capture intact

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c6629238832ba789d31479997471)