### PR TITLE
Add markdown forward-search socket and `mfs` subcommand

### DIFF
--- a/pydifftools/continuous.py
+++ b/pydifftools/continuous.py
@@ -190,6 +190,9 @@ position
         # Use Chromium DevTools search to locate text and scroll it into view.
         if not search_text:
             return
+        # Enable the DOM agent before searching to avoid inspector errors.
+        self.firefox.execute_cdp_cmd("DOM.enable", {})
+        self.firefox.execute_cdp_cmd("Runtime.enable", {})
         search_result = self.firefox.execute_cdp_cmd(
             "DOM.performSearch",
             {

--- a/pydifftools/continuous.py
+++ b/pydifftools/continuous.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import os
 import re
+import shutil
 import socket
 import threading
 import queue
@@ -210,6 +211,21 @@ position
         )
         if not found:
             print("forward search did not find text:", search_text)
+        # Bring the browser window to the foreground in Linux window managers.
+        if os.name == "posix" and shutil.which("wmctrl"):
+            window_title = self.firefox.execute_script("return document.title;")
+            if window_title:
+                # Try common Chromium title forms used by desktop environments.
+                for title_candidate in [
+                    window_title,
+                    window_title + " - Google Chrome",
+                    window_title + " - Chromium",
+                    window_title + " - Chrome",
+                ]:
+                    subprocess.run(
+                        ["wmctrl", "-a", title_candidate],
+                        check=False,
+                    )
 
 
 @register_command(


### PR DESCRIPTION
### Motivation
- Allow editors or external tools to request a forward-search into the HTML produced and served by the continuous pandoc build (`cpb`) so the browser can jump to matching markdown text.  
- Integrate a simple socket-based mechanism so `cpb` can receive search requests while watching and refreshing the HTML output.

### Description
- Added `FORWARD_SEARCH_HOST` and `FORWARD_SEARCH_PORT` and a `forward_search_listener` function in `pydifftools/continuous.py` that accepts TCP connections and queues incoming search payloads.  
- Added a `Handler.forward_search` method that executes JS via Selenium (`self.firefox.execute_script`) to find, highlight, and scroll to the first occurrence of the requested text in the rendered document.  
- Spawned a background thread and `queue.Queue` in `cpb` to run the listener and poll queued searches in the main loop, and added clean shutdown via a `stop_event`.  
- Added a new CLI subcommand `mfs` in `pydifftools/command_line.py` that connects to the `cpb` socket and sends the search text (usage: `pydifft mfs "search text"`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970385e80f8832baf6fbf0b8ddbcd9a)