### PR TITLE
Refine date-ordered rendering and simplify watcher signatures

### DIFF
--- a/pydifftools/flowchart/graph.py
+++ b/pydifftools/flowchart/graph.py
@@ -362,7 +362,10 @@ def _normalize_graph_dates(data):
         return
     default_date = datetime(date.today().year, 1, 1)
     for name in data["nodes"]:
-        if "due" in data["nodes"][name] and data["nodes"][name]["due"] is not None:
+        if (
+            "due" in data["nodes"][name]
+            and data["nodes"][name]["due"] is not None
+        ):
             if str(data["nodes"][name]["due"]).strip():
                 parsed = parse_due_string(
                     str(data["nodes"][name]["due"]).strip(),
@@ -383,8 +386,9 @@ def _normalize_graph_dates(data):
                 )
 
 
-def _append_node(lines, indent, node_name, data, wrap_width, order_by_date,
-                 sort_order):
+def _append_node(
+    lines, indent, node_name, data, wrap_width, order_by_date, sort_order
+):
     # Add a node line with an optional sort hint so Graphviz keeps date order.
     if node_name in data["nodes"]:
         label = _node_label(
@@ -464,9 +468,9 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False):
         if order_by_date and name not in ordered_set:
             continue
         if "style" in data["nodes"][name] and data["nodes"][name]["style"]:
-            style_members.setdefault(
-                data["nodes"][name]["style"], []
-            ).append(name)
+            style_members.setdefault(data["nodes"][name]["style"], []).append(
+                name
+            )
 
     for style_name in data["styles"]:
         if style_name not in style_members:
@@ -481,12 +485,16 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False):
             if isinstance(data["styles"][style_name]["attrs"]["node"], list):
                 attr_str = ", ".join(
                     f"{k}={v}"
-                    for k, v in data["styles"][style_name]["attrs"]["node"][0].items()
+                    for k, v in data["styles"][style_name]["attrs"]["node"][
+                        0
+                    ].items()
                 )
             else:
                 attr_str = ", ".join(
                     f"{k}={v}"
-                    for k, v in data["styles"][style_name]["attrs"]["node"].items()
+                    for k, v in data["styles"][style_name]["attrs"][
+                        "node"
+                    ].items()
                 )
             lines.append(f"        node [{attr_str}];")
         for node_name in style_members[style_name]:
@@ -522,12 +530,10 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False):
         for index in range(0, len(ordered_names), column_count):
             lines.append(
                 "    { rank=same; "
-                + "; ".join(
-                    ordered_names[index:index + column_count]
-                )
+                + "; ".join(ordered_names[index : index + column_count])
                 + "; }"
             )
-            row_nodes = ordered_names[index:index + column_count]
+            row_nodes = ordered_names[index : index + column_count]
             for row_index in range(len(row_nodes) - 1):
                 lines.append(
                     f"    {row_nodes[row_index]} ->"

--- a/pydifftools/flowchart/graph.py
+++ b/pydifftools/flowchart/graph.py
@@ -437,22 +437,64 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False):
         ]
         sort_order = {name: index for index, name in enumerate(ordered_names)}
     handled = set()
-    if order_by_date:
-        # In date-ordered mode, ignore style subgraphs so ordering is global.
-        if ordered_names is None:
-            ordered_names = list(data["nodes"].keys())
-        for name in ordered_names:
+    # Group nodes by their declared style so they share subgraph attributes.
+    style_members = {}
+    for name in data["nodes"]:
+        if "style" in data["nodes"][name] and data["nodes"][name]["style"]:
+            style_members.setdefault(
+                data["nodes"][name]["style"], []
+            ).append(name)
+
+    for style_name in data["styles"]:
+        if style_name not in style_members:
+            continue
+        if not style_members[style_name]:
+            continue
+        lines.append(f"    subgraph {style_name} {{")
+        if (
+            "attrs" in data["styles"][style_name]
+            and "node" in data["styles"][style_name]["attrs"]
+        ):
+            if isinstance(data["styles"][style_name]["attrs"]["node"], list):
+                attr_str = ", ".join(
+                    f"{k}={v}"
+                    for k, v in data["styles"][style_name]["attrs"]["node"][0].items()
+                )
+            else:
+                attr_str = ", ".join(
+                    f"{k}={v}"
+                    for k, v in data["styles"][style_name]["attrs"]["node"].items()
+                )
+            lines.append(f"        node [{attr_str}];")
+        for node_name in style_members[style_name]:
             _append_node(
                 lines,
-                "    ",
-                name,
+                "        ",
+                node_name,
                 data,
                 wrap_width,
                 order_by_date,
                 sort_order,
             )
-            handled.add(name)
-        # Arrange nodes in a grid of roughly five columns, left to right.
+            handled.add(node_name)
+        lines.append("    };")
+
+    if ordered_names is None:
+        ordered_names = list(data["nodes"].keys())
+    for name in ordered_names:
+        if name in handled:
+            continue
+        _append_node(
+            lines,
+            "    ",
+            name,
+            data,
+            wrap_width,
+            order_by_date,
+            sort_order,
+        )
+    if order_by_date:
+        # Arrange nodes in a grid while preserving style subgraphs.
         column_count = 5
         for index in range(0, len(ordered_names), column_count):
             lines.append(
@@ -474,64 +516,6 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False):
                 f" {ordered_names[index + column_count]} [style=invis];"
             )
     else:
-        # Group nodes by their declared style so they share subgraph attributes.
-        style_members = {}
-        for name in data["nodes"]:
-            if "style" in data["nodes"][name] and data["nodes"][name]["style"]:
-                style_members.setdefault(
-                    data["nodes"][name]["style"], []
-                ).append(name)
-
-        for style_name in data["styles"]:
-            if style_name not in style_members:
-                continue
-            if not style_members[style_name]:
-                continue
-            lines.append(f"    subgraph {style_name} {{")
-            if (
-                "attrs" in data["styles"][style_name]
-                and "node" in data["styles"][style_name]["attrs"]
-            ):
-                if isinstance(
-                    data["styles"][style_name]["attrs"]["node"], list
-                ):
-                    attr_str = ", ".join(
-                        f"{k}={v}"
-                        for k, v in data["styles"][style_name]["attrs"]["node"][0].items()
-                    )
-                else:
-                    attr_str = ", ".join(
-                        f"{k}={v}"
-                        for k, v in data["styles"][style_name]["attrs"]["node"].items()
-                    )
-                lines.append(f"        node [{attr_str}];")
-            for node_name in style_members[style_name]:
-                _append_node(
-                    lines,
-                    "        ",
-                    node_name,
-                    data,
-                    wrap_width,
-                    order_by_date,
-                    sort_order,
-                )
-                handled.add(node_name)
-            lines.append("    };")
-
-        if ordered_names is None:
-            ordered_names = list(data["nodes"].keys())
-        for name in ordered_names:
-            if name in handled:
-                continue
-            _append_node(
-                lines,
-                "    ",
-                name,
-                data,
-                wrap_width,
-                order_by_date,
-                sort_order,
-            )
         # Edges are omitted when ordering by date so boxes stand alone.
         for name in data["nodes"]:
             if "children" in data["nodes"][name]:

--- a/pydifftools/flowchart/watch_graph.py
+++ b/pydifftools/flowchart/watch_graph.py
@@ -1,7 +1,6 @@
 import subprocess
 import time
 from pathlib import Path
-from typing import Dict, Any
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 from pydifftools.command_registry import register_command
@@ -27,16 +26,18 @@ def _reload_svg(driver, svg_file: Path) -> None:
 
 
 def build_graph(
-    yaml_file: Path,
-    dot_file: Path,
-    svg_file: Path,
-    wrap_width: int,
-    prev_data: Dict[str, Any] | None = None,
-) -> Dict[str, Any]:
+    yaml_file,
+    dot_file,
+    svg_file,
+    wrap_width,
+    order_by_date=False,
+    prev_data=None,
+):
     data = write_dot_from_yaml(
         str(yaml_file),
         str(dot_file),
         wrap_width=wrap_width,
+        order_by_date=order_by_date,
         old_data=prev_data,
     )
     subprocess.run(
@@ -53,10 +54,10 @@ class GraphEventHandler(FileSystemEventHandler):
         dot_file,
         svg_file,
         driver,
-        wrap_width: int,
-        data: Dict[str, Any] | None,
-        *,
-        debounce: float = 0.25,
+        wrap_width,
+        data,
+        order_by_date=False,
+        debounce=0.25,
     ):
         self.yaml_file = Path(yaml_file)
         self.dot_file = Path(dot_file)
@@ -64,6 +65,7 @@ class GraphEventHandler(FileSystemEventHandler):
         self.driver = driver
         self.wrap_width = wrap_width
         self.data = data
+        self.order_by_date = order_by_date
         self.debounce = debounce
         self._last_handled = 0.0
         self._last_mtime = None
@@ -82,6 +84,7 @@ class GraphEventHandler(FileSystemEventHandler):
                 self.dot_file,
                 self.svg_file,
                 self.wrap_width,
+                self.order_by_date,
                 self.data,
             )
             _reload_svg(self.driver, self.svg_file)
@@ -94,9 +97,10 @@ class GraphEventHandler(FileSystemEventHandler):
     help={
         "yaml": "Path to the flowchart YAML file",
         "wrap_width": "Line wrap width used when generating node labels",
+        "d": "Render nodes by date without showing connections",
     },
 )
-def wgrph(yaml, wrap_width=55):
+def wgrph(yaml, wrap_width=55, d=False):
     # Selenium is only required when actually launching the watcher, so it is
     # imported here to avoid breaking the command-line tools when the optional
     # dependency is not installed.
@@ -120,7 +124,8 @@ def wgrph(yaml, wrap_width=55):
     svg_file = yaml_file.with_suffix(".svg")
     html_file = yaml_file.with_suffix(".html")
 
-    data = build_graph(yaml_file, dot_file, svg_file, wrap_width)
+    # Use date ordering when requested so boxes appear in calendar order.
+    data = build_graph(yaml_file, dot_file, svg_file, wrap_width, d)
     html_file.write_text(
         "<html><body style='margin:0'><embed id='svg-view'"
         " type='image/svg+xml'"
@@ -130,7 +135,7 @@ def wgrph(yaml, wrap_width=55):
     driver = webdriver.Chrome(options=options)
     driver.get(html_file.resolve().as_uri())
     event_handler = GraphEventHandler(
-        yaml_file, dot_file, svg_file, driver, wrap_width, data
+        yaml_file, dot_file, svg_file, driver, wrap_width, data, d
     )
     observer = Observer()
     observer.schedule(event_handler, yaml_file.parent, recursive=False)


### PR DESCRIPTION
### Motivation
- Provide a reliable date-ordered rendering mode for `wgrph` so nodes can be displayed in calendar order without connections. 
- Reduce duplicated node-emission logic and tighten conditionals that determine when style subgraphs and edges are emitted. 
- Conform to readability constraints by removing explicit typing and starred arg usage in updated functions.

### Description
- Added an `order_by_date` parameter to `yaml_to_dot` and `write_dot_from_yaml` and compute a stable `ordered_names` list and `sort_order` mapping by parsing `due`/`orig_due` values (via the existing parser). 
- Emit `sortv` attributes for nodes when `order_by_date` is enabled and omit edge output in that mode so boxes are standalone, while keeping style subgraphs scoped to only the relevant members. 
- Introduced a single `_append_node` helper to centralize node-line emission and remove duplicated code paths for styled and unstyled nodes. 
- Simplified function signatures and removed explicit type annotations/star args in `yaml_to_dot`, `write_dot_from_yaml`, `build_graph`, `GraphEventHandler.__init__`, and `wgrph`, and wired the `d` CLI flag through the live watcher (`GraphEventHandler`) so the date-ordered toggle is honored on rebuilds.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69727f09bfc8832bad68aa1d4612ba20)