### PR TITLE
Use conda tools and libs for CLI subprocess tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install requirements
         run: |
           sudo apt-get update
-          sudo apt-get install -y pandoc
+          sudo apt-get install -y pandoc graphviz
           wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
           bash Miniforge3.sh -b -p "${HOME}/conda"
           source "${HOME}/conda/etc/profile.d/conda.sh"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,14 +64,25 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y pandoc
+          wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+          bash Miniforge3.sh -b -p "${HOME}/conda"
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          # For mamba support also run the following command
+          source "${HOME}/conda/etc/profile.d/mamba.sh"
+          conda activate base
           python -m pip install --upgrade pip
           pip install pytest
+          conda install -y -c conda-forge pandoc-crossref
       - name: Install project for testing
         run: |
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          conda activate base
           pip install -e . --no-build-isolation
-
       - name: Run pytest
-        run: pytest
+        run: |
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          conda activate base
+          pytest
 
       - name: Determine next version
         id: determine

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,10 +18,22 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y pandoc
-      - name: Install pytest
-        run: |
+          wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+          bash Miniforge3.sh -b -p "${HOME}/conda"
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          # For mamba support also run the following command
+          source "${HOME}/conda/etc/profile.d/mamba.sh"
+          conda activate base
           python -m pip install --upgrade pip
-          pip install .
           pip install pytest
-      - name: Run PyTest
-        run: pytest
+          conda install -y -c conda-forge pandoc-crossref
+      - name: Install project for testing
+        run: |
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          conda activate base
+          pip install -e . --no-build-isolation
+      - name: Run pytest
+        run: |
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          conda activate base
+          pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Pandoc
         run: |
           sudo apt-get update
-          sudo apt-get install -y pandoc
+          sudo apt-get install -y pandoc graphviz
           wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
           bash Miniforge3.sh -b -p "${HOME}/conda"
           source "${HOME}/conda/etc/profile.d/conda.sh"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,6 @@
   can be added to environment setup scripts.
 - Never skip tests for missing external tools. If a dependency is missing,
   allow the test to fail and include the exact install commands in the response.
+- When running tests in this repo, prepend the conda site-packages so pytest
+  can import conda-managed dependencies: use
+  `PYTHONPATH=/root/conda/lib/python3.12/site-packages pytest`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,5 @@
 - Tests may fail due to missing external tools only if the response includes
   the exact Unix command(s) needed to install the missing dependencies so they
   can be added to environment setup scripts.
+- Never skip tests for missing external tools. If a dependency is missing,
+  allow the test to fail and include the exact install commands in the response.

--- a/pydifftools/continuous.py
+++ b/pydifftools/continuous.py
@@ -5,12 +5,25 @@ import subprocess
 import sys
 import os
 import re
+import shutil
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 from .command_registry import register_command
 
 
 def run_pandoc(filename, html_file):
+    # Pandoc and pandoc-crossref must be installed for HTML rendering.
+    if shutil.which("pandoc") is None:
+        raise RuntimeError(
+            "Pandoc must be installed to render HTML output. Install pandoc"
+            " so the 'pandoc' executable is available on your PATH."
+        )
+    if shutil.which("pandoc-crossref") is None:
+        raise RuntimeError(
+            "Pandoc-crossref must be installed to render HTML output. Install"
+            " pandoc-crossref so the 'pandoc-crossref' executable is available"
+            " on your PATH."
+        )
     if os.path.exists("MathJax-3.1.2"):
         has_local_jax = True
     else:

--- a/pydifftools/flowchart/graph.py
+++ b/pydifftools/flowchart/graph.py
@@ -2,29 +2,11 @@ from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple
 from datetime import date, datetime
 
-import os
-import shutil
-import tempfile
 import textwrap
 import re
 import yaml
 from dateutil.parser import parse as parse_due_string
 from yaml.emitter import ScalarAnalysis
-
-if shutil.which("dot") is None:
-    # Provide a lightweight fallback for environments without Graphviz so the
-    # flowchart tests can still render stub SVG output.
-    _dot_dir = Path(tempfile.mkdtemp(prefix="pydt_dot_"))
-    _dot_path = _dot_dir / "dot"
-    _dot_path.write_text(
-        "#!/usr/bin/env python3\nimport sys, pathlib\nargs = sys.argv\noutfile"
-        " = args[args.index('-o') + 1] if '-o' in args else None\nif"
-        " outfile:\n    path = pathlib.Path(outfile)\n   "
-        ' path.write_text("<svg'
-        " xmlns='http://www.w3.org/2000/svg'></svg>\\n\")\nsys.exit(0)\n"
-    )
-    _dot_path.chmod(0o755)
-    os.environ["PATH"] = f"{_dot_dir}{os.pathsep}" + os.environ.get("PATH", "")
 
 
 class IndentDumper(yaml.SafeDumper):

--- a/pydifftools/flowchart/watch_graph.py
+++ b/pydifftools/flowchart/watch_graph.py
@@ -1,5 +1,6 @@
 import subprocess
 import time
+import shutil
 from pathlib import Path
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
@@ -33,6 +34,12 @@ def build_graph(
     order_by_date=False,
     prev_data=None,
 ):
+    # Graphviz is required for dot -> svg rendering.
+    if shutil.which("dot") is None:
+        raise RuntimeError(
+            "Graphviz is required to render flowcharts. Install it so the"
+            " 'dot' executable is available on your PATH."
+        )
     data = write_dot_from_yaml(
         str(yaml_file),
         str(dot_file),
@@ -114,7 +121,8 @@ def wgrph(yaml, wrap_width=55, d=False):
         )
     except ImportError as exc:
         raise ImportError(
-            "The 'watch_graph' command requires the 'selenium' package."
+            "The 'watch_graph' command requires the 'selenium' package to be"
+            " installed."
         ) from exc
 
     yaml_file = Path(yaml)

--- a/tests/flowchart/test_inline_code_font.py
+++ b/tests/flowchart/test_inline_code_font.py
@@ -23,6 +23,6 @@ def test_inline_code_wrapped_with_courier_font(tmp_path):
     assert m, "label not found"
     label = m.group(1)
 
-    assert "<font face=\"Courier\">inline code</font>" in label
-    assert "<font face=\"Courier\">second bit</font>" in label
+    assert '<font face="Courier">inline code</font>' in label
+    assert '<font face="Courier">second bit</font>' in label
     assert "`" not in label

--- a/tests/flowchart/test_linebreaks.py
+++ b/tests/flowchart/test_linebreaks.py
@@ -3,22 +3,17 @@ import yaml
 
 from pydifftools.flowchart.graph import write_dot_from_yaml
 
+
 def test_single_linebreak_ignored(tmp_path):
-    data = {
-        'nodes': {
-            'A': {
-                'text': 'First line\nsecond line'
-            }
-        }
-    }
-    yaml_path = tmp_path / 'g.yaml'
-    with open(yaml_path, 'w') as f:
+    data = {"nodes": {"A": {"text": "First line\nsecond line"}}}
+    yaml_path = tmp_path / "g.yaml"
+    with open(yaml_path, "w") as f:
         yaml.safe_dump(data, f, allow_unicode=True)
-    dot_path = tmp_path / 'g.dot'
+    dot_path = tmp_path / "g.dot"
     write_dot_from_yaml(yaml_path, dot_path, wrap_width=100)
     text = dot_path.read_text()
-    m = re.search(r'A \[label=<(.*?)>\];', text, re.S)
-    assert m, 'label not found'
+    m = re.search(r"A \[label=<(.*?)>\];", text, re.S)
+    assert m, "label not found"
     label = m.group(1)
-    assert 'First line second line' in label
-    assert 'First line\nsecond line' not in label
+    assert "First line second line" in label
+    assert "First line\nsecond line" not in label

--- a/tests/flowchart/test_list_indentation.py
+++ b/tests/flowchart/test_list_indentation.py
@@ -1,4 +1,3 @@
-import sys, pathlib
 import re
 import yaml
 

--- a/tests/flowchart/test_list_indentation.py
+++ b/tests/flowchart/test_list_indentation.py
@@ -7,48 +7,48 @@ from pydifftools.flowchart.graph import write_dot_from_yaml
 
 def _extract_segments(label: str):
     parts = re.findall(r'([^<]*)<br align="left"/>', label)
-    return [p.rstrip('\n').split('\n')[-1] for p in parts]
+    return [p.rstrip("\n").split("\n")[-1] for p in parts]
 
 
 def test_bullet_overflow_indent(tmp_path):
     data = {
-        'nodes': {
-            'A': {
-                'text': '* ' + 'word ' * 20,
+        "nodes": {
+            "A": {
+                "text": "* " + "word " * 20,
             }
         }
     }
-    yaml_path = tmp_path / 'g.yaml'
-    with open(yaml_path, 'w') as f:
+    yaml_path = tmp_path / "g.yaml"
+    with open(yaml_path, "w") as f:
         yaml.safe_dump(data, f, allow_unicode=True)
-    dot_path = tmp_path / 'g.dot'
+    dot_path = tmp_path / "g.dot"
     write_dot_from_yaml(yaml_path, dot_path, wrap_width=20)
     text = dot_path.read_text()
-    m = re.search(r'A \[label=<(.*?)>\];', text, re.S)
-    assert m, 'label not found'
+    m = re.search(r"A \[label=<(.*?)>\];", text, re.S)
+    assert m, "label not found"
     label = m.group(1)
     segments = _extract_segments(label)
-    assert segments[0].startswith('• ')
-    assert segments[1].startswith('  ')
+    assert segments[0].startswith("• ")
+    assert segments[1].startswith("  ")
 
 
 def test_numbered_overflow_indent(tmp_path):
     data = {
-        'nodes': {
-            'A': {
-                'text': '1. ' + 'word ' * 20,
+        "nodes": {
+            "A": {
+                "text": "1. " + "word " * 20,
             }
         }
     }
-    yaml_path = tmp_path / 'g.yaml'
-    with open(yaml_path, 'w') as f:
+    yaml_path = tmp_path / "g.yaml"
+    with open(yaml_path, "w") as f:
         yaml.safe_dump(data, f, allow_unicode=True)
-    dot_path = tmp_path / 'g.dot'
+    dot_path = tmp_path / "g.dot"
     write_dot_from_yaml(yaml_path, dot_path, wrap_width=20)
     text = dot_path.read_text()
-    m = re.search(r'A \[label=<(.*?)>\];', text, re.S)
-    assert m, 'label not found'
+    m = re.search(r"A \[label=<(.*?)>\];", text, re.S)
+    assert m, "label not found"
     label = m.group(1)
     segments = _extract_segments(label)
-    assert segments[0].startswith('1. ')
-    assert segments[1].startswith('  ')
+    assert segments[0].startswith("1. ")
+    assert segments[1].startswith("  ")

--- a/tests/flowchart/test_numbered_lists.py
+++ b/tests/flowchart/test_numbered_lists.py
@@ -5,20 +5,21 @@ import yaml
 from pydifftools.flowchart.dot_to_yaml import dot_to_yaml
 from pydifftools.flowchart.graph import write_dot_from_yaml
 
+
 def test_numbered_lines(tmp_path):
-    source_dot = pathlib.Path(__file__).with_name('magnet_setup.dot')
-    tmp_yaml = tmp_path / 'out.yaml'
+    source_dot = pathlib.Path(__file__).with_name("magnet_setup.dot")
+    tmp_yaml = tmp_path / "out.yaml"
     dot_to_yaml(str(source_dot), tmp_yaml)
     data = yaml.safe_load(tmp_yaml.read_text())
-    lines = data['nodes']['Disconnect']['text'].splitlines()
-    assert lines[3].startswith('1.')
-    assert lines[4].startswith('2.')
-    assert lines[5].startswith('3.')
-    generated_dot = tmp_path / 'from_yaml.dot'
+    lines = data["nodes"]["Disconnect"]["text"].splitlines()
+    assert lines[3].startswith("1.")
+    assert lines[4].startswith("2.")
+    assert lines[5].startswith("3.")
+    generated_dot = tmp_path / "from_yaml.dot"
     write_dot_from_yaml(tmp_yaml, generated_dot)
     text = generated_dot.read_text()
-    m = re.search(r'Disconnect \[label=<(.*?)>\];', text, re.S)
-    assert m, 'label not found'
+    m = re.search(r"Disconnect \[label=<(.*?)>\];", text, re.S)
+    assert m, "label not found"
     label = m.group(1)
     assert re.search(r'<br align="left"/>\n\s*2\. Add notes', label)
-    assert label.strip().endswith('<br align="left"/>' + '\n</font>')
+    assert label.strip().endswith('<br align="left"/>' + "\n</font>")

--- a/tests/flowchart/test_observation_tags.py
+++ b/tests/flowchart/test_observation_tags.py
@@ -5,13 +5,7 @@ from pydifftools.flowchart.graph import write_dot_from_yaml
 
 
 def test_observation_tags_rendered(tmp_path):
-    data = {
-        "nodes": {
-            "A": {
-                "text": "Before <obs>Observation</obs> after"
-            }
-        }
-    }
+    data = {"nodes": {"A": {"text": "Before <obs>Observation</obs> after"}}}
     yaml_path = tmp_path / "obs.yaml"
     with open(yaml_path, "w") as f:
         yaml.safe_dump(data, f, allow_unicode=True)
@@ -23,7 +17,7 @@ def test_observation_tags_rendered(tmp_path):
     assert m, "label not found"
     label = m.group(1)
 
-    assert "<font color=\"blue\">→Observation</font>" in label
+    assert '<font color="blue">→Observation</font>' in label
     assert "<obs>" not in label
     assert "</obs>" not in label
-    assert "→Observation</font> after\n<br align=\"left\"/>" in label
+    assert '→Observation</font> after\n<br align="left"/>' in label

--- a/tests/flowchart/test_relationship_sync.py
+++ b/tests/flowchart/test_relationship_sync.py
@@ -4,8 +4,8 @@ from pydifftools.flowchart.graph import write_dot_from_yaml
 
 
 def test_relationship_removal_updates_yaml(tmp_path):
-    yaml_path = tmp_path / 'graph.yaml'
-    yaml_path.write_text('''\
+    yaml_path = tmp_path / "graph.yaml"
+    yaml_path.write_text("""\
 nodes:
   BringInNewDesk:
     children: []
@@ -14,16 +14,16 @@ nodes:
     children: []
     parents:
     - BringInNewDesk
-''')
-    dot_path = tmp_path / 'graph.dot'
+""")
+    dot_path = tmp_path / "graph.dot"
     write_dot_from_yaml(yaml_path, dot_path)
     data = yaml.safe_load(yaml_path.read_text())
-    assert data['nodes']['SetUpDedicatedComputer']['parents'] == []
+    assert data["nodes"]["SetUpDedicatedComputer"]["parents"] == []
 
 
 def test_parent_removal_updates_yaml(tmp_path):
-    yaml_path = tmp_path / 'graph.yaml'
-    yaml_path.write_text('''\
+    yaml_path = tmp_path / "graph.yaml"
+    yaml_path.write_text("""\
 nodes:
   EstimateRatio:
     children:
@@ -33,21 +33,21 @@ nodes:
     children: []
     parents:
     - EstimateRatio
-''')
-    dot_path = tmp_path / 'graph.dot'
+""")
+    dot_path = tmp_path / "graph.dot"
     data = write_dot_from_yaml(yaml_path, dot_path)
     data_yaml = yaml.safe_load(yaml_path.read_text())
     # simulate user removing parent link only
-    data_yaml['nodes']['CheckMagnet']['parents'] = []
+    data_yaml["nodes"]["CheckMagnet"]["parents"] = []
     yaml_path.write_text(yaml.safe_dump(data_yaml))
     write_dot_from_yaml(yaml_path, dot_path, old_data=data)
     updated = yaml.safe_load(yaml_path.read_text())
-    assert 'CheckMagnet' not in updated['nodes']['EstimateRatio']['children']
+    assert "CheckMagnet" not in updated["nodes"]["EstimateRatio"]["children"]
 
 
 def test_node_removal_cleans_references(tmp_path):
-    yaml_path = tmp_path / 'graph.yaml'
-    yaml_path.write_text('''\
+    yaml_path = tmp_path / "graph.yaml"
+    yaml_path.write_text("""\
 nodes:
   A:
     children:
@@ -57,13 +57,13 @@ nodes:
     children: []
     parents:
     - A
-''')
-    dot_path = tmp_path / 'graph.dot'
+""")
+    dot_path = tmp_path / "graph.dot"
     data = write_dot_from_yaml(yaml_path, dot_path)
     data_yaml = yaml.safe_load(yaml_path.read_text())
-    del data_yaml['nodes']['B']
+    del data_yaml["nodes"]["B"]
     yaml_path.write_text(yaml.safe_dump(data_yaml))
     write_dot_from_yaml(yaml_path, dot_path, old_data=data)
     updated = yaml.safe_load(yaml_path.read_text())
-    assert 'B' not in updated['nodes']
-    assert 'B' not in updated['nodes']['A']['children']
+    assert "B" not in updated["nodes"]
+    assert "B" not in updated["nodes"]["A"]["children"]

--- a/tests/flowchart/test_svg.py
+++ b/tests/flowchart/test_svg.py
@@ -10,20 +10,22 @@ from selenium.webdriver.chrome.service import Service
 
 def test_svg_render(tmp_path):
 
-    dot_file = tmp_path / 'graph.dot'
-    svg_file = tmp_path / 'graph.svg'
-    tmp_yaml = tmp_path / 'graph.yaml'
-    fixture_yaml = pathlib.Path(__file__).with_name('magnet_setup.yaml')
+    dot_file = tmp_path / "graph.dot"
+    svg_file = tmp_path / "graph.svg"
+    tmp_yaml = tmp_path / "graph.yaml"
+    fixture_yaml = pathlib.Path(__file__).with_name("magnet_setup.yaml")
     tmp_yaml.write_text(fixture_yaml.read_text())
     write_dot_from_yaml(tmp_yaml, dot_file)
-    subprocess.run(['dot', '-Tsvg', str(dot_file), '-o', str(svg_file)], check=True)
+    subprocess.run(
+        ["dot", "-Tsvg", str(dot_file), "-o", str(svg_file)], check=True
+    )
     options = Options()
-    options.add_argument('--headless=new')
+    options.add_argument("--headless=new")
     try:
-        service = Service('/usr/bin/chromedriver')
+        service = Service("/usr/bin/chromedriver")
         driver = webdriver.Chrome(service=service, options=options)
     except Exception:
-        pytest.skip('chromedriver not available')
-    driver.get('file://' + str(svg_file.resolve()))
-    driver.find_element('tag name', 'svg')
+        pytest.skip("chromedriver not available")
+    driver.get("file://" + str(svg_file.resolve()))
+    driver.find_element("tag name", "svg")
     driver.quit()

--- a/tests/flowchart/test_svg.py
+++ b/tests/flowchart/test_svg.py
@@ -9,6 +9,7 @@ from selenium.webdriver.chrome.service import Service
 
 
 def test_svg_render(tmp_path):
+
     dot_file = tmp_path / 'graph.dot'
     svg_file = tmp_path / 'graph.svg'
     tmp_yaml = tmp_path / 'graph.yaml'

--- a/tests/flowchart/test_watch_debounce.py
+++ b/tests/flowchart/test_watch_debounce.py
@@ -5,27 +5,33 @@ from pydifftools.flowchart import watch_graph
 
 
 def test_yaml_write_does_not_loop(tmp_path, monkeypatch):
-    yaml_file = tmp_path / 'graph.yaml'
-    yaml_file.write_text('')
-    dot_file = tmp_path / 'graph.dot'
-    svg_file = tmp_path / 'graph.svg'
-    calls = {'build': 0, 'reload': 0}
+    yaml_file = tmp_path / "graph.yaml"
+    yaml_file.write_text("")
+    dot_file = tmp_path / "graph.dot"
+    svg_file = tmp_path / "graph.svg"
+    calls = {"build": 0, "reload": 0}
 
     def fake_build(y, d, s, w, order_by_date=False, prev=None):
-        calls['build'] += 1
+        calls["build"] += 1
         return {}
 
     def fake_reload(driver, svg):
-        calls['reload'] += 1
+        calls["reload"] += 1
 
-    monkeypatch.setattr(watch_graph, 'build_graph', fake_build)
-    monkeypatch.setattr(watch_graph, '_reload_svg', fake_reload)
+    monkeypatch.setattr(watch_graph, "build_graph", fake_build)
+    monkeypatch.setattr(watch_graph, "_reload_svg", fake_reload)
 
     handler = watch_graph.GraphEventHandler(
-        yaml_file, dot_file, svg_file, None, wrap_width=55, data=None, debounce=0.5
+        yaml_file,
+        dot_file,
+        svg_file,
+        None,
+        wrap_width=55,
+        data=None,
+        debounce=0.5,
     )
     event = types.SimpleNamespace(src_path=str(yaml_file))
     handler.on_modified(event)
     handler.on_modified(event)
-    assert calls['build'] == 1
-    assert calls['reload'] == 1
+    assert calls["build"] == 1
+    assert calls["reload"] == 1

--- a/tests/flowchart/test_watch_debounce.py
+++ b/tests/flowchart/test_watch_debounce.py
@@ -11,7 +11,7 @@ def test_yaml_write_does_not_loop(tmp_path, monkeypatch):
     svg_file = tmp_path / 'graph.svg'
     calls = {'build': 0, 'reload': 0}
 
-    def fake_build(y, d, s, w, prev=None):
+    def fake_build(y, d, s, w, order_by_date=False, prev=None):
         calls['build'] += 1
         return {}
 

--- a/tests/flowchart/test_watch_debounce.py
+++ b/tests/flowchart/test_watch_debounce.py
@@ -1,6 +1,4 @@
 import types
-import pathlib
-
 from pydifftools.flowchart import watch_graph
 
 

--- a/tests/flowchart/test_watch_reload.py
+++ b/tests/flowchart/test_watch_reload.py
@@ -10,6 +10,7 @@ from selenium.webdriver.chrome.service import Service
 
 
 def test_reload_preserves_view(tmp_path):
+
     dot_file = tmp_path / "graph.dot"
     svg_file = tmp_path / "graph.svg"
     html_file = tmp_path / "view.html"


### PR DESCRIPTION
### Motivation
- CLI subprocess tests were failing to find conda-installed tooling and Python packages (e.g. `pandoc-crossref`, `nbformat`) because the test subprocess environment did not include the maintained conda bin and site-packages paths.

### Description
- Update `_make_cli_env` in `tests/cli/test_commands.py` to prepend `/root/conda/bin` to `PATH` so subprocesses resolve conda-installed executables.
- Add `/root/conda/lib/python3.12/site-packages` into the constructed `PYTHONPATH` (while preserving any existing `PYTHONPATH`) so subprocesses can import conda-installed Python packages.
- Remove the previous local `pandoc-crossref` stub setup and related temporary `bin` handling so tests exercise the real conda-provided tools instead of a lightweight stub.

### Testing
- Ran the full test suite using `PYTHONPATH=/root/conda/lib/python3.12/site-packages pytest`, which completed successfully with `44 passed, 2 skipped`.
- Prior to this change the suite failed (5 failures) due to missing `nbformat` and missing `pandoc-crossref` from subprocesses, and those failures were resolved by the environment adjustments above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697912f9f4ec832b82e096d335763312)