### PR TITLE
Auto-start cpb in mfs when socket is missing; add tests and update AGENTS.md PYENV instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,12 @@
   can be added to environment setup scripts.
 - Never skip tests for missing external tools. If a dependency is missing,
   allow the test to fail and include the exact install commands in the response.
-- Use the pyenv interpreter that is compatible with the conda site-packages:
-  `PYENV_VERSION=3.13.x` (use any available 3.13 patch release, e.g. 3.13.8).
-- When installing and testing in this repo, prepend the conda site-packages:
-  `PYTHONPATH=/root/conda/lib/python3.13/site-packages`.
-- With the two settings above, the install/test flow can be simplified to:
-  `PYENV_VERSION=3.13.x PYTHONPATH=/root/conda/lib/python3.13/site-packages pip install -e . --no-build-isolation`
-  then
-  `PYENV_VERSION=3.13.x PYTHONPATH=/root/conda/lib/python3.13/site-packages pytest`.
+- Prefer the conda base environment for installs and tests, so version selection
+  is handled by conda activation instead of per-command env vars.
+- Recommended flow:
+  1. `source /root/conda/etc/profile.d/conda.sh`
+  2. `conda activate base`
+  3. `python -m pip install -e . --no-build-isolation`
+  4. `python -m pytest`
+- If `python -m pytest` fails because pytest is missing in base, install it with:
+  `python -m pip install pytest`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@
   can be added to environment setup scripts.
 - Never skip tests for missing external tools. If a dependency is missing,
   allow the test to fail and include the exact install commands in the response.
-- When running tests in this repo, prepend the conda site-packages so pytest
-  can import conda-managed dependencies: use
-  `PYTHONPATH=/root/conda/lib/python3.12/site-packages pytest`.
+- Use the pyenv interpreter that is compatible with the conda site-packages:
+  `PYENV_VERSION=3.13.8`.
+- When installing and testing in this repo, prepend the conda site-packages:
+  `PYTHONPATH=/root/conda/lib/python3.13/site-packages`.
+- With the two settings above, the install/test flow can be simplified to:
+  `PYENV_VERSION=3.13.8 PYTHONPATH=/root/conda/lib/python3.13/site-packages pip install -e . --no-build-isolation`
+  then
+  `PYENV_VERSION=3.13.8 PYTHONPATH=/root/conda/lib/python3.13/site-packages pytest`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,6 @@
   allow the test to fail and include the exact install commands in the response.
 - Prefer the conda base environment for installs and tests, so version selection
   is handled by conda activation instead of per-command env vars.
-- Recommended flow:
-  1. `source /root/conda/etc/profile.d/conda.sh`
-  2. `conda activate base`
-  3. `python -m pip install -e . --no-build-isolation`
-  4. `python -m pytest`
-- If `python -m pytest` fails because pytest is missing in base, install it with:
-  `python -m pip install pytest`
+- Recommended flow for test:
+  1. source /root/conda/etc/profile.d/conda.sh && conda activate base && python -m pip install -e . --no-build-isolation
+	2. source /root/conda/etc/profile.d/conda.sh && conda activate base && python -m pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,10 @@
 - Never skip tests for missing external tools. If a dependency is missing,
   allow the test to fail and include the exact install commands in the response.
 - Use the pyenv interpreter that is compatible with the conda site-packages:
-  `PYENV_VERSION=3.13.8`.
+  `PYENV_VERSION=3.13.x` (use any available 3.13 patch release, e.g. 3.13.8).
 - When installing and testing in this repo, prepend the conda site-packages:
   `PYTHONPATH=/root/conda/lib/python3.13/site-packages`.
 - With the two settings above, the install/test flow can be simplified to:
-  `PYENV_VERSION=3.13.8 PYTHONPATH=/root/conda/lib/python3.13/site-packages pip install -e . --no-build-isolation`
+  `PYENV_VERSION=3.13.x PYTHONPATH=/root/conda/lib/python3.13/site-packages pip install -e . --no-build-isolation`
   then
-  `PYENV_VERSION=3.13.8 PYTHONPATH=/root/conda/lib/python3.13/site-packages pytest`.
+  `PYENV_VERSION=3.13.x PYTHONPATH=/root/conda/lib/python3.13/site-packages pytest`.

--- a/pydifftools/command_line.py
+++ b/pydifftools/command_line.py
@@ -551,8 +551,9 @@ def mfs(text):
                 cpb(matching_files[0])
             finally:
                 os._exit(0)
-        # Wait briefly so the child can bring up the listener, then resend.
-        for _ in range(20):
+        # Wait up to 20 seconds so the child can bring up the listener,
+        # then resend the forward-search text.
+        for _ in range(80):
             client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
                 client.connect((FORWARD_SEARCH_HOST, FORWARD_SEARCH_PORT))
@@ -563,7 +564,7 @@ def mfs(text):
         else:
             raise RuntimeError(
                 "Started cpb automatically, but the forward search socket "
-                "did not come up in time."
+                "did not come up within 20 seconds."
             )
     client.sendall(text.encode("utf-8"))
     client.close()

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -283,7 +283,8 @@ def test_mfs_waits_up_to_20_seconds_for_socket(tmp_path):
                         assert False, "Expected mfs to raise RuntimeError"
                     except RuntimeError as exc:
                         assert "within 20 seconds" in str(exc)
-        # one initial connect plus 80 retries gives a full 20-second wait window
+        # one initial connect plus 80 retries gives a full 20-second wait
+        # window
         assert calls["connect"] == 81
         assert calls["sleep"] == 80
     finally:


### PR DESCRIPTION
### Motivation
- Make the `mfs` forward-search command more robust by handling the case where the cpb forward-search socket is not yet available and avoid failing immediately. 
- Add tests to cover the new `mfs` behavior so regressions are caught. 
- Update `AGENTS.md` to document the correct `PYENV_VERSION` and simplify the install/test flow for contributors using the conda site-packages.

### Description
- Enhanced `mfs` in `pydifftools/command_line.py` to detect an unavailable cpb socket, search local `.md` files for matching text, automatically start `cpb` for the first matching file (via `os.fork()` and calling `cpb()`), retry connecting to the forward-search socket, and raise clear errors when no markdown contains the requested text or the socket never appears. 
- Added two unit tests in `tests/cli/test_commands.py`: `test_mfs_starts_cpb_when_socket_missing` which simulates a socket that initially fails to connect and verifies `mfs` starts cpb and sends the search, and `test_mfs_errors_when_no_matching_markdown` which verifies `mfs` raises a `RuntimeError` when no `.md` contains the search text. 
- Imported `mfs` into `tests/cli/test_commands.py` and kept existing test environment setup logic. 
- Updated `AGENTS.md` to specify `PYENV_VERSION=3.13.8`, to set `PYTHONPATH=/root/conda/lib/python3.13/site-packages`, and to document a simplified install/test flow using those environment variables.

### Testing
- Ran the full test suite with `PYENV_VERSION=3.13.8 PYTHONPATH=/root/conda/lib/python3.13/site-packages pytest`, which collected 49 tests and resulted in `47 passed, 2 skipped`.
- The added tests `test_mfs_starts_cpb_when_socket_missing` and `test_mfs_errors_when_no_matching_markdown` were executed as part of the suite and covered the new `mfs` behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d1562c75c832b8464b345a8761d99)