### PR TITLE
Unify browser shutdown handling for cpb and wgrph watchers

### DIFF
--- a/pydifftools/browser_lifecycle.py
+++ b/pydifftools/browser_lifecycle.py
@@ -1,0 +1,24 @@
+def browser_window_is_alive(browser):
+    # Keep all browser liveness checks in one place so watch commands share
+    # the same shutdown behavior when a user closes the browser window.
+    if browser is None:
+        return False
+    try:
+        handles = browser.window_handles
+        if not handles:
+            return False
+        browser.execute_script("return 1")
+        return True
+    except Exception:
+        return False
+
+
+def close_browser_window(browser):
+    # Close a Selenium browser session and ignore errors from already-closed
+    # windows so cleanup paths stay simple.
+    if browser is None:
+        return
+    try:
+        browser.quit()
+    except Exception:
+        pass

--- a/tests/test_browser_lifecycle.py
+++ b/tests/test_browser_lifecycle.py
@@ -1,0 +1,41 @@
+from pydifftools import browser_lifecycle
+
+
+class FakeBrowser:
+    def __init__(self, handles=None, script_error=False, quit_error=False):
+        self.window_handles = handles if handles is not None else ["main"]
+        self.script_error = script_error
+        self.quit_error = quit_error
+        self.quit_calls = 0
+
+    def execute_script(self, _code):
+        if self.script_error:
+            raise RuntimeError("window closed")
+        return 1
+
+    def quit(self):
+        self.quit_calls += 1
+        if self.quit_error:
+            raise RuntimeError("already closed")
+
+
+def test_browser_window_is_alive_true():
+    browser = FakeBrowser(handles=["main"])
+    assert browser_lifecycle.browser_window_is_alive(browser)
+
+
+def test_browser_window_is_alive_false_when_handles_missing():
+    browser = FakeBrowser(handles=[])
+    assert not browser_lifecycle.browser_window_is_alive(browser)
+
+
+def test_browser_window_is_alive_false_when_script_errors():
+    browser = FakeBrowser(script_error=True)
+    assert not browser_lifecycle.browser_window_is_alive(browser)
+
+
+def test_close_browser_window_quits_and_swallows_errors():
+    browser = FakeBrowser(quit_error=True)
+    browser_lifecycle.close_browser_window(browser)
+    assert browser.quit_calls == 1
+    browser_lifecycle.close_browser_window(None)

--- a/tests/test_continuous_shutdown.py
+++ b/tests/test_continuous_shutdown.py
@@ -1,0 +1,63 @@
+from pydifftools import continuous
+
+
+class FakeObserver:
+    def __init__(self):
+        self.stopped = False
+        self.joined = False
+
+    def schedule(self, handler, path=".", recursive=False):
+        self.handler = handler
+
+    def start(self):
+        return
+
+    def stop(self):
+        self.stopped = True
+
+    def join(self):
+        self.joined = True
+
+
+class FakeThread:
+    def __init__(self, target=None, args=None, daemon=False):
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+        self.joined = False
+
+    def start(self):
+        self.started = True
+
+    def join(self):
+        self.joined = True
+
+
+class FakeHandler:
+    def __init__(self, filename, observer):
+        self.filename = filename
+        self.observer = observer
+        self.firefox = object()
+
+    def forward_search(self, _search_text):
+        return
+
+
+def test_cpb_exits_when_browser_window_closed(monkeypatch):
+    close_calls = []
+
+    monkeypatch.setattr(continuous, "Observer", FakeObserver)
+    monkeypatch.setattr(continuous, "Handler", FakeHandler)
+    monkeypatch.setattr(continuous.threading, "Thread", FakeThread)
+    monkeypatch.setattr(
+        continuous,
+        "browser_window_is_alive",
+        lambda _browser: False,
+    )
+    monkeypatch.setattr(continuous, "close_browser_window", close_calls.append)
+    monkeypatch.setattr(continuous.time, "sleep", lambda _seconds: None)
+
+    continuous.cpb("notes.md")
+
+    assert len(close_calls) == 1


### PR DESCRIPTION
### Motivation
- Ensure watcher commands do not remain running after the user closes the browser window by centralizing browser liveness and teardown logic.
- `wgrph` and `cpb` previously could leave the pydifft process alive when Chrome was closed, while `qmdb` already handled this correctly.
- Provide a single, reusable implementation so all watcher paths behave consistently on browser close.

### Description
- Add `pydifftools/browser_lifecycle.py` with `browser_window_is_alive` and `close_browser_window` to centralize Selenium liveness checks and safe teardown.
- Update `cpb` (`pydifftools/continuous.py`) to break its watch loop when the browser is closed and to perform observer/socket/browser cleanup in a `finally` block using the new helpers.
- Update `wgrph` (`pydifftools/flowchart/watch_graph.py`) to use `browser_window_is_alive` and `close_browser_window` and exit the watcher loop when the browser window is closed.
- Update `qmdb` refresh/liveness/cleanup paths (`pydifftools/notebook/fast_build.py`) to reuse the same helpers for consistent behavior across watchers.\
- Add unit tests `tests/test_browser_lifecycle.py` for the helper functions and `tests/test_continuous_shutdown.py` to verify `cpb` exits when browser liveness is lost.

### Testing
- Installed the package in editable mode with `python -m pip install -e . --no-build-isolation` using the conda `base` environment. 
- Ran the full test suite with `python -m pytest` and observed all tests passing locally with the summary `56 passed, 2 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699624470d50832b91f6aafd1f08fe9c)