### PR TITLE
Add shared Pygments CSS asset for notebook display pages

### DIFF
--- a/tests/notebook/test_fast_build.py
+++ b/tests/notebook/test_fast_build.py
@@ -115,6 +115,29 @@ def test_postprocess_nested_includes(fb, tmp_path, monkeypatch):
     assert "data-include" not in html
 
 
+def test_postprocess_adds_shared_pygments_stylesheet_link(fb, tmp_path):
+    build_dir = tmp_path / "build"
+    display_dir = tmp_path / "display"
+    build_dir.mkdir()
+    display_dir.mkdir()
+
+    page = display_dir / "index.html"
+    page.write_text(
+        "<html><head></head><body>"
+        '<div class="highlight"><pre>'
+        '<span class="k">print</span>'
+        "</pre></div>"
+        "</body></html>"
+    )
+
+    fb.postprocess_html(page, build_dir, display_dir)
+
+    html = page.read_text()
+    assert 'href="assets/pygments.css"' in html
+    css = (display_dir / "assets" / "pygments.css").read_text()
+    assert ".highlight" in css
+
+
 def test_navigation_persists_after_notebook_updates(fb):
     fb.build_all()
     render_files = fb.load_rendered_files()


### PR DESCRIPTION
### Motivation
- Assembled display pages could lose syntax highlighting when child fragments provide highlighted markup but their head style blocks are dropped during include expansion, so a single shared stylesheet is needed for consistent code coloring.

### Description
- Add a `PYGMENTS_CSS` asset path and implement `ensure_pygments_css(resource_root)` to write Pygments CSS into the display asset tree.
- Update `postprocess_html` to always ensure a document-level link to the shared `pygments.css`, creating a `<head>` if necessary and avoiding duplicate links.
- Invoke `ensure_pygments_css(DISPLAY_DIR)` from `build_all()` so the shared stylesheet exists before display pages are assembled.
- Add `test_postprocess_adds_shared_pygments_stylesheet_link` to verify the stylesheet link is injected and the `assets/pygments.css` file is written with `.highlight` rules.

### Testing
- `python -m pip install -e . --no-build-isolation` completed successfully when run in the environment used for the changes.
- Running the full test suite with `python -m pytest` produced failures (12 failing tests) due to missing external tools required by unrelated tests, notably `pandoc`/`pandoc-crossref` and Graphviz (`dot`).
- Targeted tests for this change were run with `python -m pytest tests/notebook/test_fast_build.py::test_postprocess_nested_includes tests/notebook/test_fast_build.py::test_postprocess_adds_shared_pygments_stylesheet_link` and both passed.
- To allow the full suite to run in CI or locally, install the missing external tools with `conda install -n base -c conda-forge pandoc pandoc-crossref graphviz`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b6c85fc8832b89d2b17b9017db35)