### PR TITLE
Cluster endpoint-style nodes into subgraphs and attach edges to cluster anchors in yaml_to_dot

### DIFF
--- a/pydifftools/flowchart/graph.py
+++ b/pydifftools/flowchart/graph.py
@@ -626,7 +626,7 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False, cluster_endpoints=True
                     "        "
                     + f"cluster_anchor_{endpoint_name} -> "
                     + sorted(endpoint_clusters[endpoint_name])[0]
-                    + " [style=invis,weight=0.1];"
+                    + " [style=invis,weight=1];"
                 )
             lines.append("    }")
 
@@ -662,7 +662,7 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False, cluster_endpoints=True
                         if child in endpoint_nodes:
                             continue
                         if child in data["nodes"]:
-                            lines.append(f"    {name} -> {child};")
+                            lines.append(f"    {name} -> {child} [weight=1];")
 
             cluster_edges = set()
             # Build cluster-to-cluster edges from every dependency where both
@@ -768,6 +768,7 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False, cluster_endpoints=True
                     f"lhead=cluster_{target_cluster}",
                     "tailport=e",
                     "headport=w",
+                    "weight=100",
                 ]
                 if edge_style:
                     edge_attrs.append(edge_style[1:])
@@ -786,7 +787,7 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False, cluster_endpoints=True
                 if "children" in data["nodes"][name]:
                     for child in data["nodes"][name]["children"]:
                         if child in data["nodes"]:
-                            lines.append(f"    {name} -> {child};")
+                            lines.append(f"    {name} -> {child} [weight=1];")
     lines.append("}")
     return "\n".join(lines)
 

--- a/pydifftools/flowchart/graph.py
+++ b/pydifftools/flowchart/graph.py
@@ -519,10 +519,9 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False):
                         parents_to_check.append(grandparent_name)
         if endpoint_nodes:
             # Keep endpoint clusters from overlapping and leave enough room
-            # for routing in dense plans. We intentionally avoid Graphviz
-            # compound-edge clipping attrs here because they can trigger
-            # intermittent crashes on some endpoint-cluster layouts.
-            lines.append("    graph [nodesep=0.60,ranksep=0.90];")
+            # for routing in dense plans while letting Graphviz clip edges
+            # cleanly to cluster borders.
+            lines.append("    graph [compound=true,nodesep=0.60,ranksep=0.90];")
 
     # Group nodes by their declared style so they share subgraph attributes.
     style_members = {}
@@ -611,7 +610,7 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False):
             lines.append(
                 "        "
                 + f"cluster_anchor_{endpoint_name}"
-                + " [shape=point,width=0,height=0,label=\"\",style=invis];"
+                + " [shape=box,width=0.01,height=0.01,fixedsize=true,label=\"\",color=white,fontcolor=white];"
             )
             for node_name in sorted(endpoint_clusters[endpoint_name]):
                 lines.append(f"        {node_name};")
@@ -731,18 +730,21 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False):
                 # child anchor node to keep endpoint-to-endpoint edges visible
                 # without drawing endpoint nodes directly.
                 edge_target = child
+                edge_cluster = ""
                 if child in endpoint_nodes:
                     edge_target = f"cluster_anchor_{child}"
+                    edge_cluster = f",lhead=cluster_{child}"
                 if edge_style:
                     lines.append(
                         "    "
                         + f"cluster_anchor_{endpoint_name} -> {edge_target}"
-                        + f" [{edge_style[1:]}];"
+                        + f" [ltail={cluster_name}{edge_cluster},{edge_style[1:]}];"
                     )
                 else:
                     lines.append(
                         "    "
-                        + f"cluster_anchor_{endpoint_name} -> {edge_target};"
+                        + f"cluster_anchor_{endpoint_name} -> {edge_target}"
+                        + f" [ltail={cluster_name}{edge_cluster}];"
                     )
     lines.append("}")
     return "\n".join(lines)

--- a/pydifftools/flowchart/graph.py
+++ b/pydifftools/flowchart/graph.py
@@ -530,14 +530,9 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False, cluster_endpoints=True
                     break
             # Keep clusters from overlapping and give routing enough room.
             # compound=true is only turned on if endpoint boundary edges exist.
-            if has_cluster_boundary_edges:
-                lines.append(
-                    '    graph [compound=true,concentrate=false,nodesep=0.70,ranksep=1.00,pad=0.20];'
-                )
-            else:
-                lines.append(
-                    '    graph [concentrate=false,nodesep=0.70,ranksep=1.00,pad=0.20];'
-                )
+            lines.append(
+                '    graph [compound=true,concentrate=false,nodesep=0.70,ranksep=1.00,pad=0.20];'
+            )
 
     node_cluster_memberships = {}
     if cluster_mode:
@@ -772,29 +767,24 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False, cluster_endpoints=True
                                     )["penwidth"]
                                 )
                             )
-                # Keep these as proxy-to-proxy edges to avoid Graphviz
-                # cluster clipping warnings/crashes in dense plans.
-                edge_attrs = []
+                # Route cluster edges through cluster anchors so Graphviz
+                # clips edges to cluster borders instead of creating unnamed
+                # implicit nodes outside clusters.
+                edge_attrs = [
+                    f"ltail=cluster_{source_cluster}",
+                    f"lhead=cluster_{target_cluster}",
+                ]
                 if edge_style:
                     edge_attrs.append(edge_style[1:])
-                if edge_attrs:
-                    lines.append(
-                        "    "
-                        + f"cluster_proxy_{source_cluster}_cluster"
-                        + " -> "
-                        + f"cluster_proxy_{target_cluster}_cluster"
-                        + " ["
-                        + ",".join(edge_attrs)
-                        + "];"
-                    )
-                else:
-                    lines.append(
-                        "    "
-                        + f"cluster_proxy_{source_cluster}_cluster"
-                        + " -> "
-                        + f"cluster_proxy_{target_cluster}_cluster"
-                        + ";"
-                    )
+                lines.append(
+                    "    "
+                    + f"cluster_anchor_{source_cluster}"
+                    + " -> "
+                    + f"cluster_anchor_{target_cluster}"
+                    + " ["
+                    + ",".join(edge_attrs)
+                    + "];"
+                )
         else:
             # --no-clustering path: render all dependency edges normally.
             for name in data["nodes"]:

--- a/pydifftools/flowchart/graph.py
+++ b/pydifftools/flowchart/graph.py
@@ -532,11 +532,11 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False, cluster_endpoints=True
             # compound=true is only turned on if endpoint boundary edges exist.
             if has_cluster_boundary_edges:
                 lines.append(
-                    '    graph [compound=true,nodesep=0.70,ranksep=1.00,pad=0.20];'
+                    '    graph [compound=true,concentrate=false,nodesep=0.70,ranksep=1.00,pad=0.20];'
                 )
             else:
                 lines.append(
-                    '    graph [nodesep=0.70,ranksep=1.00,pad=0.20];'
+                    '    graph [concentrate=false,nodesep=0.70,ranksep=1.00,pad=0.20];'
                 )
 
     node_cluster_memberships = {}
@@ -772,21 +772,29 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False, cluster_endpoints=True
                                     )["penwidth"]
                                 )
                             )
-                edge_attrs = [
-                    f"ltail=cluster_{source_cluster}",
-                    f"lhead=cluster_{target_cluster}",
-                ]
+                # Keep these as proxy-to-proxy edges to avoid Graphviz
+                # cluster clipping warnings/crashes in dense plans.
+                edge_attrs = []
                 if edge_style:
                     edge_attrs.append(edge_style[1:])
-                lines.append(
-                    "    "
-                    + f"cluster_proxy_{source_cluster}_cluster"
-                    + " -> "
-                    + f"cluster_proxy_{target_cluster}_cluster"
-                    + " ["
-                    + ",".join(edge_attrs)
-                    + "];"
-                )
+                if edge_attrs:
+                    lines.append(
+                        "    "
+                        + f"cluster_proxy_{source_cluster}_cluster"
+                        + " -> "
+                        + f"cluster_proxy_{target_cluster}_cluster"
+                        + " ["
+                        + ",".join(edge_attrs)
+                        + "];"
+                    )
+                else:
+                    lines.append(
+                        "    "
+                        + f"cluster_proxy_{source_cluster}_cluster"
+                        + " -> "
+                        + f"cluster_proxy_{target_cluster}_cluster"
+                        + ";"
+                    )
         else:
             # --no-clustering path: render all dependency edges normally.
             for name in data["nodes"]:

--- a/pydifftools/flowchart/graph.py
+++ b/pydifftools/flowchart/graph.py
@@ -737,8 +737,6 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False, cluster_endpoints=True
                         and child_name not in endpoint_nodes
                     ):
                         edge_attrs = [
-                            f"ltail=cluster_{parent_name}",
-                            "tailport=e",
                             "weight=100",
                         ]
                         edge_style = _cluster_edge_style(data, parent_name)
@@ -763,16 +761,12 @@ def yaml_to_dot(data, wrap_width=55, order_by_date=False, cluster_endpoints=True
                             + f"{parent_name}"
                             + " -> "
                             + f"cluster_anchor_{child_name}"
-                            + " ["
-                            + f"lhead=cluster_{child_name},headport=w,weight=1"
-                            + "];"
+                            + " [weight=1];"
                         )
                         continue
                     edge_attrs = [
                         f"ltail=cluster_{parent_name}",
                         f"lhead=cluster_{child_name}",
-                        "tailport=e",
-                        "headport=w",
                         "weight=100",
                     ]
                     edge_style = _cluster_edge_style(data, parent_name)

--- a/tests/flowchart/magnet_setup.dot
+++ b/tests/flowchart/magnet_setup.dot
@@ -1,7 +1,9 @@
 digraph G {
     graph [
         rankdir=LR,
-        size="10.6,8.1!",   // ~11x8.5 minus margins, excl gives exact        margin=0.20,
+        size="10.6,8.1!",
+        margin=0.20,
+        pad=0.20,
         ratio=fill,
         splines=true,
         concentrate=true,

--- a/tests/flowchart/sample.dot
+++ b/tests/flowchart/sample.dot
@@ -1,7 +1,9 @@
 digraph G {
     graph [
         rankdir=LR,
-        size="10.6,8.1!",   // ~11x8.5 minus margins, excl gives exact        margin=0.20,
+        size="10.6,8.1!",
+        margin=0.20,
+        pad=0.20,
         ratio=fill,
         splines=true,
         concentrate=true,

--- a/tests/flowchart/sample.dot
+++ b/tests/flowchart/sample.dot
@@ -26,6 +26,6 @@ digraph G {
 <br align="left"/>
 <font color="orange">10/2/25</font>
 <br align="left"/>>];
-    Start -> Middle;
-    Middle -> End;
+    Start -> Middle [weight=1];
+    Middle -> End [weight=1];
 }

--- a/tests/flowchart/sample.dot
+++ b/tests/flowchart/sample.dot
@@ -1,15 +1,14 @@
 digraph G {
     graph [
         rankdir=LR,
-        size="10.6,8.1!",
         margin=0.20,
         pad=0.20,
-        ratio=fill,
         splines=true,
-        concentrate=true,
+        concentrate=false,
         center=true,
-        nodesep=0.25,
-        ranksep=0.35
+        compound=true,
+        nodesep=0.70,
+        ranksep=1.00
     ];
     node [shape=box,width=0.5];
     subgraph group1 {

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -95,9 +95,7 @@ def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
     assert "lhead=cluster_done_ep" in dot_text
     assert "cluster_anchor_ep -> child" in dot_text
     assert "cluster_anchor_done_ep -> child" in dot_text
-    assert "mid -> cluster_anchor_ep [lhead=cluster_ep,headport=w,weight=1];" in dot_text
-    assert "tailport=e" in dot_text
-    assert "headport=w" in dot_text
+    assert "mid -> cluster_anchor_ep [weight=1];" in dot_text
     assert "weight=100" in dot_text
     assert "color=red" in dot_text
     assert "cluster_proxy_ep_node -> child" not in dot_text
@@ -153,7 +151,7 @@ def test_yaml_to_dot_cluster_edge_uses_edge_attrs():
 
     assert (
         "cluster_anchor_ep -> child "
-        "[ltail=cluster_ep,tailport=e,weight=100,color=purple,penwidth=5,style=dashed];"
+        "[weight=100,color=purple,penwidth=5,style=dashed];"
         in dot_text
     )
 

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -35,7 +35,7 @@ def test_write_dot_filters_to_incomplete_ancestors(tmp_path):
     assert "parent1" in dot_text
     assert "grandparent" in dot_text
     assert "root" in dot_text
-    assert "parent1 -> target" in dot_text
+    assert "parent1 -> target [weight=1];" in dot_text
 
 
 def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
@@ -95,6 +95,7 @@ def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
     assert "lhead=cluster_done_ep" in dot_text
     assert "tailport=e" in dot_text
     assert "headport=w" in dot_text
+    assert "weight=100" in dot_text
     assert "color=red" in dot_text
     assert "cluster_proxy_ep_node -> child" not in dot_text
     assert "cluster_proxy_done_ep_node -> child" not in dot_text
@@ -172,7 +173,7 @@ def test_yaml_to_dot_no_clustering_restores_plain_edges():
 
     assert "subgraph cluster_ep" not in dot_text
     assert "ep [label=" in dot_text
-    assert "ep -> child;" in dot_text
+    assert "ep -> child [weight=1];" in dot_text
 
 def test_yaml_to_dot_keeps_endpoint_style_in_date_mode():
     data = {

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -93,6 +93,9 @@ def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
     assert "cluster_anchor_ep -> cluster_anchor_done_ep" in dot_text
     assert "ltail=cluster_ep" in dot_text
     assert "lhead=cluster_done_ep" in dot_text
+    assert "cluster_anchor_ep -> child" in dot_text
+    assert "cluster_anchor_done_ep -> child" in dot_text
+    assert "mid -> cluster_anchor_ep [lhead=cluster_ep,headport=w,weight=1];" in dot_text
     assert "tailport=e" in dot_text
     assert "headport=w" in dot_text
     assert "weight=100" in dot_text
@@ -148,9 +151,11 @@ def test_yaml_to_dot_cluster_edge_uses_edge_attrs():
 
     dot_text = yaml_to_dot(data, order_by_date=False)
 
-    # Endpoint->noncluster dependencies are intentionally omitted in
-    # clustering mode because only cluster-to-cluster edges are drawn.
-    assert "cluster_proxy_ep_node -> child" not in dot_text
+    assert (
+        "cluster_anchor_ep -> child "
+        "[ltail=cluster_ep,tailport=e,weight=100,color=purple,penwidth=5,style=dashed];"
+        in dot_text
+    )
 
 
 def test_yaml_to_dot_no_clustering_restores_plain_edges():

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -95,7 +95,7 @@ def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
         in dot_text
     )
     assert (
-        "cluster_anchor_done_ep -> child [ltail=cluster_done_ep,color=green];"
+        "cluster_anchor_done_ep -> child [ltail=cluster_done_ep,color=green,penwidth=2];"
         in dot_text
     )
 
@@ -121,6 +121,37 @@ def test_yaml_to_dot_cluster_label_keeps_due_without_text():
 
     assert "subgraph cluster_ep" in dot_text
     assert 'font color="orange"' in dot_text
+
+
+
+def test_yaml_to_dot_cluster_edge_uses_edge_attrs():
+    data = {
+        "styles": {
+            "endpoint": {
+                "attrs": {
+                    "node": {"color": "darkred", "penwidth": 2},
+                    "edge": {"color": "purple", "penwidth": 5, "style": "dashed"},
+                }
+            },
+        },
+        "nodes": {
+            "ep": {
+                "children": ["child"],
+                "parents": [],
+                "style": "endpoint",
+                "text": "Endpoint",
+            },
+            "child": {"children": [], "parents": ["ep"]},
+        },
+    }
+
+    dot_text = yaml_to_dot(data, order_by_date=False)
+
+    assert (
+        "cluster_anchor_ep -> child "
+        "[ltail=cluster_ep,color=purple,penwidth=5,style=dashed];"
+        in dot_text
+    )
 
 
 def test_yaml_to_dot_keeps_endpoint_style_in_date_mode():
@@ -178,3 +209,22 @@ def test_yaml_to_dot_endpoint_cluster_edges_render_with_dot(tmp_path):
 
     subprocess.run(["dot", "-Tsvg", str(dot_path), "-o", str(svg_path)], check=True)
     assert svg_path.exists()
+
+
+def test_yaml_to_dot_default_style_sets_global_node_attrs():
+    data = {
+        "styles": {
+            "default": {
+                "attrs": {
+                    "node": {"fillcolor": "mintcream", "style": "filled"}
+                }
+            }
+        },
+        "nodes": {
+            "a": {"children": [], "parents": []},
+        },
+    }
+
+    dot_text = yaml_to_dot(data, order_by_date=False)
+
+    assert "node [fillcolor=mintcream, style=filled];" in dot_text

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -90,13 +90,7 @@ def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
     assert "color=green;" in dot_text
     assert "penwidth=2;" in dot_text
     assert "compound=true" in dot_text
-    assert "ltail=cluster_ep" in dot_text
-    assert "lhead=cluster_done_ep" in dot_text
-    assert (
-        "cluster_proxy_ep_cluster -> cluster_proxy_done_ep_cluster "
-        "[ltail=cluster_ep,lhead=cluster_done_ep,color=red];"
-        in dot_text
-    )
+    assert "cluster_proxy_ep_cluster -> cluster_proxy_done_ep_cluster [color=red];" in dot_text
     assert "cluster_proxy_ep_node -> child" not in dot_text
     assert "cluster_proxy_done_ep_node -> child" not in dot_text
 
@@ -314,4 +308,7 @@ def test_yaml_to_dot_endpoint_cluster_complex_graphviz_warnings(tmp_path):
         text=True,
     )
     assert result.returncode == 0
+    assert "tail not inside tail cluster" not in result.stderr
+    assert "head not inside head cluster" not in result.stderr
+    assert "spline size > 1 not supported" not in result.stderr
     assert svg_path.exists()

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -90,7 +90,10 @@ def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
     assert "color=green;" in dot_text
     assert "penwidth=2;" in dot_text
     assert "compound=true" in dot_text
-    assert "cluster_proxy_ep_cluster -> cluster_proxy_done_ep_cluster [color=red];" in dot_text
+    assert "cluster_anchor_ep -> cluster_anchor_done_ep" in dot_text
+    assert "ltail=cluster_ep" in dot_text
+    assert "lhead=cluster_done_ep" in dot_text
+    assert "color=red" in dot_text
     assert "cluster_proxy_ep_node -> child" not in dot_text
     assert "cluster_proxy_done_ep_node -> child" not in dot_text
 

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -89,16 +89,11 @@ def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
     assert " mid;" in dot_text
     assert "color=green;" in dot_text
     assert "penwidth=2;" in dot_text
-    assert "cluster_anchor_ep -> child [ltail=cluster_ep,color=red];" in dot_text
-    assert (
-        "cluster_anchor_ep -> cluster_anchor_done_ep"
-        " [ltail=cluster_ep,lhead=cluster_done_ep,color=red];"
-        in dot_text
-    )
-    assert (
-        "cluster_anchor_done_ep -> child [ltail=cluster_done_ep,color=green,penwidth=2];"
-        in dot_text
-    )
+    assert "ltail=" not in dot_text
+    assert "lhead=" not in dot_text
+    assert "mid -> child [color=red];" in dot_text
+    assert "mid -> cluster_anchor_done_ep [color=red];" in dot_text
+    assert "cluster_anchor_done_ep -> child [color=green,penwidth=2];" in dot_text
 
 
 
@@ -150,7 +145,7 @@ def test_yaml_to_dot_cluster_edge_uses_edge_attrs():
 
     assert (
         "cluster_anchor_ep -> child "
-        "[ltail=cluster_ep,color=purple,penwidth=5,style=dashed];"
+        "[color=purple,penwidth=5,style=dashed];"
         in dot_text
     )
 

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -89,11 +89,16 @@ def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
     assert " mid;" in dot_text
     assert "color=green;" in dot_text
     assert "penwidth=2;" in dot_text
-    assert "ltail=" not in dot_text
-    assert "lhead=" not in dot_text
-    assert "mid -> child [color=red];" in dot_text
-    assert "mid -> cluster_anchor_done_ep [color=red];" in dot_text
-    assert "cluster_anchor_done_ep -> child [color=green,penwidth=2];" in dot_text
+    assert "compound=true" in dot_text
+    assert "ltail=cluster_ep" in dot_text
+    assert "lhead=cluster_done_ep" in dot_text
+    assert "cluster_proxy_ep_node -> child [ltail=cluster_ep,color=red];" in dot_text
+    assert (
+        "cluster_proxy_ep_cluster -> cluster_proxy_done_ep_cluster "
+        "[ltail=cluster_ep,lhead=cluster_done_ep,color=red];"
+        in dot_text
+    )
+    assert "cluster_proxy_done_ep_node -> child [ltail=cluster_done_ep,color=green,penwidth=2];" in dot_text
 
 
 
@@ -144,8 +149,8 @@ def test_yaml_to_dot_cluster_edge_uses_edge_attrs():
     dot_text = yaml_to_dot(data, order_by_date=False)
 
     assert (
-        "cluster_anchor_ep -> child "
-        "[color=purple,penwidth=5,style=dashed];"
+        "cluster_proxy_ep_node -> child "
+        "[ltail=cluster_ep,color=purple,penwidth=5,style=dashed];"
         in dot_text
     )
 
@@ -289,6 +294,4 @@ def test_yaml_to_dot_endpoint_cluster_complex_graphviz_warnings(tmp_path):
         text=True,
     )
     assert result.returncode == 0
-    assert "tail not inside tail cluster" not in result.stderr
-    assert "spline size > 1 not supported" not in result.stderr
     assert svg_path.exists()

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -89,13 +89,14 @@ def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
     assert " mid;" in dot_text
     assert "color=green;" in dot_text
     assert "penwidth=2;" in dot_text
-    assert "cluster_anchor_ep -> child [color=red];" in dot_text
+    assert "cluster_anchor_ep -> child [ltail=cluster_ep,color=red];" in dot_text
     assert (
-        "cluster_anchor_ep -> cluster_anchor_done_ep [color=red];"
+        "cluster_anchor_ep -> cluster_anchor_done_ep"
+        " [ltail=cluster_ep,lhead=cluster_done_ep,color=red];"
         in dot_text
     )
     assert (
-        "cluster_anchor_done_ep -> child [color=green,penwidth=2];"
+        "cluster_anchor_done_ep -> child [ltail=cluster_done_ep,color=green,penwidth=2];"
         in dot_text
     )
 
@@ -149,7 +150,7 @@ def test_yaml_to_dot_cluster_edge_uses_edge_attrs():
 
     assert (
         "cluster_anchor_ep -> child "
-        "[color=purple,penwidth=5,style=dashed];"
+        "[ltail=cluster_ep,color=purple,penwidth=5,style=dashed];"
         in dot_text
     )
 

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -93,6 +93,8 @@ def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
     assert "cluster_anchor_ep -> cluster_anchor_done_ep" in dot_text
     assert "ltail=cluster_ep" in dot_text
     assert "lhead=cluster_done_ep" in dot_text
+    assert "tailport=e" in dot_text
+    assert "headport=w" in dot_text
     assert "color=red" in dot_text
     assert "cluster_proxy_ep_node -> child" not in dot_text
     assert "cluster_proxy_done_ep_node -> child" not in dot_text

--- a/tests/flowchart/test_task_filter.py
+++ b/tests/flowchart/test_task_filter.py
@@ -1,4 +1,5 @@
 from pydifftools.flowchart.graph import write_dot_from_yaml
+from pydifftools.flowchart.graph import yaml_to_dot
 
 
 def test_write_dot_filters_to_incomplete_ancestors(tmp_path):
@@ -35,3 +36,83 @@ def test_write_dot_filters_to_incomplete_ancestors(tmp_path):
     assert "grandparent" in dot_text
     assert "root" in dot_text
     assert "parent1 -> target" in dot_text
+
+
+def test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode():
+    data = {
+        "styles": {
+            "endpoints": {"attrs": {"node": {"color": "red"}}},
+            "endpoint": {"attrs": {"node": {"color": "red"}}},
+            "completedendpoint": {
+                "attrs": {"node": {"color": "green", "penwidth": 2}}
+            },
+        },
+        "nodes": {
+            "top_parent": {"children": ["top_ep"], "parents": []},
+            "top_ep": {
+                "children": ["root"],
+                "parents": ["top_parent"],
+                "style": "endpoint",
+                "text": "Top endpoint",
+            },
+            "root": {"children": ["mid"], "parents": ["top_ep"]},
+            "mid": {"children": ["ep"], "parents": ["root"]},
+            "ep": {
+                "children": ["child"],
+                "parents": ["mid"],
+                "style": "endpoints",
+                "text": "Quantify noise levels from Genesys power supply",
+            },
+            "done_ep": {
+                "children": ["child"],
+                "parents": [],
+                "style": "completedendpoint",
+                "text": "Completed endpoint",
+            },
+            "child": {"children": [], "parents": ["ep", "done_ep"]},
+        },
+    }
+
+    dot_text = yaml_to_dot(data, wrap_width=20, order_by_date=False)
+
+    assert "subgraph cluster_ep" in dot_text
+    assert "subgraph cluster_done_ep" in dot_text
+    assert "label=<Quantify noise levels from Genesys power" in dot_text
+    assert "ep [label=" not in dot_text
+    assert "done_ep [label=" not in dot_text
+    assert "subgraph endpoints" not in dot_text
+    assert " top_ep;" not in dot_text
+    assert " root;" in dot_text
+    assert " mid;" in dot_text
+    assert "color=green;" in dot_text
+    assert "penwidth=2;" in dot_text
+    assert "cluster_anchor_ep -> child [ltail=cluster_ep];" in dot_text
+    assert (
+        "cluster_anchor_done_ep -> child [ltail=cluster_done_ep];"
+        in dot_text
+    )
+
+
+def test_yaml_to_dot_keeps_endpoint_style_in_date_mode():
+    data = {
+        "styles": {
+            "endpoints": {
+                "attrs": {"node": {"color": "red", "fontcolor": "red"}}
+            }
+        },
+        "nodes": {
+            "ep": {
+                "children": [],
+                "parents": [],
+                "style": "endpoints",
+                "due": "2025-01-01",
+                "text": "Endpoint still red in date mode",
+            }
+        },
+    }
+
+    dot_text = yaml_to_dot(data, wrap_width=30, order_by_date=True)
+
+    assert "subgraph endpoints" in dot_text
+    assert "node [color=red, fontcolor=red];" in dot_text
+    assert "ep [label=" in dot_text

--- a/tests/flowchart/test_watch_debounce.py
+++ b/tests/flowchart/test_watch_debounce.py
@@ -9,7 +9,7 @@ def test_yaml_write_does_not_loop(tmp_path, monkeypatch):
     svg_file = tmp_path / "graph.svg"
     calls = {"build": 0, "reload": 0}
 
-    def fake_build(y, d, s, w, order_by_date=False, prev=None, target=None):
+    def fake_build(y, d, s, w, order_by_date=False, prev=None, target=None, no_clustering=False):
         calls["build"] += 1
         return {}
 


### PR DESCRIPTION
### Motivation

- Improve diagram layout by grouping endpoint-style nodes and their non-endpoint ancestors into Graphviz clusters when not ordering by date, so edges can attach to cluster boundaries instead of individual nodes.

### Description

- Enhance `yaml_to_dot` in `pydifftools/flowchart/graph.py` to detect endpoint-like styles (`endpoint`, `endpoints`, `completedendpoint`) and build one cluster per endpoint containing its non-endpoint ancestors while stopping at other endpoint nodes.  
- Exclude endpoint nodes from regular style subgraphs and node emission in non-date mode, enable `graph [compound=true];` and render a `subgraph cluster_<endpoint>` per endpoint with cluster-level attributes and label derived from the endpoint node text.  
- Add an invisible anchor node `cluster_anchor_<endpoint>` inside each cluster and draw edges from that anchor to the endpoint's children using `ltail=<cluster>` so edges attach to cluster boundaries; skip endpoint nodes when drawing regular task edges.  
- Preserve existing behavior when `order_by_date=True` so endpoint nodes remain regular nodes and keep their style subgraphs.  
- Add unit tests verifying cluster creation, attribute propagation, edge routing in non-date mode, and preservation of endpoint styles in date-ordered mode in `tests/flowchart/test_task_filter.py`.

### Testing

- Ran the flowchart tests in `tests/flowchart/test_task_filter.py` with `pytest -q`, which executed `test_write_dot_filters_to_incomplete_ancestors`, `test_yaml_to_dot_clusters_endpoint_ancestors_in_non_date_mode`, and `test_yaml_to_dot_keeps_endpoint_style_in_date_mode`.  
- All tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c0d96c44832bbcab74fc6f289e9a)