### PR TITLE
Add endpoint-based project bubbles and coloring in wgrph SVGs

### DIFF
--- a/tests/flowchart/test_project_bubbles.py
+++ b/tests/flowchart/test_project_bubbles.py
@@ -1,0 +1,61 @@
+import xml.etree.ElementTree as ET
+
+from pydifftools.flowchart.watch_graph import build_graph
+
+
+def test_build_graph_adds_project_bubbles(tmp_path):
+    yaml_file = tmp_path / "graph.yaml"
+    dot_file = tmp_path / "graph.dot"
+    svg_file = tmp_path / "graph.svg"
+    yaml_file.write_text(
+        """
+nodes:
+  root:
+    text: Root
+    children: [mid, end2]
+  mid:
+    text: Mid
+    children: [end1]
+  end1:
+    text: End 1
+  end2:
+    text: End 2
+""".strip()
+    )
+
+    build_graph(yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False)
+
+    tree = ET.parse(svg_file)
+    root = tree.getroot()
+    namespace = ""
+    if root.tag.startswith("{"):
+        namespace = root.tag[: root.tag.find("}") + 1]
+
+    title_to_group = {}
+    bubble_group = None
+    for group in root.iter(f"{namespace}g"):
+        if "id" in group.attrib and group.attrib["id"] == "project-bubbles":
+            bubble_group = group
+        for child in group:
+            if child.tag == f"{namespace}title" and child.text is not None:
+                title_to_group[child.text.strip()] = group
+
+    assert bubble_group is not None
+    bubbles = [child for child in bubble_group if child.tag == f"{namespace}path"]
+    assert len(bubbles) == 2
+
+    endpoint_colors = {}
+    for endpoint in ["end1", "end2"]:
+        for child in title_to_group[endpoint]:
+            if child.tag == f"{namespace}polygon" and "stroke" in child.attrib:
+                endpoint_colors[endpoint] = child.attrib["stroke"]
+                break
+        assert endpoint in endpoint_colors
+
+    bubble_strokes = set()
+    for bubble in bubbles:
+        bubble_strokes.add(bubble.attrib["stroke"])
+        assert bubble.attrib["fill"] == "#00000011"
+
+    assert endpoint_colors["end1"] in bubble_strokes
+    assert endpoint_colors["end2"] in bubble_strokes


### PR DESCRIPTION
### Motivation
- Enhance the `wgrph`/`watch_graph` behavior when not using `-d` so each endpoint highlights its project (endpoint + ancestors) visually in the generated SVG. 
- Make it possible to identify endpoint nodes in the SVG and draw non-overlapping, smooth bubble overlays behind the graph to group project nodes for easier visual scanning.

### Description
- Post-process the generated SVG in `pydifftools/flowchart/watch_graph.py` when `order_by_date` (`-d`) is not set to detect endpoints and build a `projects` mapping where each project lists the endpoint first followed by its ancestors, stopping at any ancestor that is itself an endpoint. 
- Map rendered SVG node groups to their node names by scanning `<g>` elements and `<title>` children so shapes can be modified programmatically. 
- Generate a high-saturation rainbow palette in Lab color space with equal lightness and evenly spaced a/b angles and assign a unique color to each endpoint. 
- Recolor endpoint node outlines in the SVG with the assigned endpoint color and insert a new SVG `<g id="project-bubbles">` layer containing smooth bezier bubble `<path>` overlays for each project, drawing bubbles behind existing objects with `fill="#00000011"` and a stroke matching the endpoint color. 
- Add unit test `tests/flowchart/test_project_bubbles.py` to verify that bubble overlays are produced and that bubble stroke colors correspond to endpoint node strokes. 

### Testing
- Installed the package in editable mode with `source /root/conda/etc/profile.d/conda.sh && conda activate base && python -m pip install -e . --no-build-isolation` which completed successfully. 
- Ran the full test suite with `source /root/conda/etc/profile.d/conda.sh && conda activate base && python -m pytest` and observed all tests passing: `66 passed, 2 skipped` (with warnings unrelated to the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc96ad7e4832bb5340cea8dbed47f)