### PR TITLE
Add clickable task links to SVG and local preview server with query-driven filtering

### DIFF
--- a/pydifftools/browser_lifecycle.py
+++ b/pydifftools/browser_lifecycle.py
@@ -1,13 +1,14 @@
 def browser_window_is_alive(browser):
     # Keep all browser liveness checks in one place so watch commands share
     # the same shutdown behavior when a user closes the browser window.
+    # Do not probe with execute_script here: page navigations can briefly
+    # interrupt script execution even while the window is still open.
     if browser is None:
         return False
     try:
         handles = browser.window_handles
         if not handles:
             return False
-        browser.execute_script("return 1")
         return True
     except Exception:
         return False

--- a/pydifftools/continuous.py
+++ b/pydifftools/continuous.py
@@ -312,7 +312,8 @@ position
             );
         });
 
-        // When the page has loaded, restore hidden comments and scroll position
+        // When the page has loaded,
+        // restore hidden comments and scroll position
         window.addEventListener('load', function() {
             var hiddenCommentIndexes = sessionStorage.getItem(
                 'commentHiddenBubbleIndexes'

--- a/pydifftools/flowchart/graph.py
+++ b/pydifftools/flowchart/graph.py
@@ -378,28 +378,24 @@ def _normalize_graph_dates(data):
 def _append_node(
     lines, indent, node_name, data, wrap_width, order_by_date, sort_order
 ):
-    # Add a node line with an optional sort hint so Graphviz keeps date order.
-    if node_name in data["nodes"]:
-        label = _node_label(
-            _node_text_with_due(data["nodes"][node_name]), wrap_width
+    # Every rendered DOT node corresponds to a real YAML node, so build the
+    # label directly from that node and prepend the task-link marker line.
+    label = _node_label(_node_text_with_due(data["nodes"][node_name]), wrap_width)
+    task_link_line = (
+        f'<font point-size="7">__WGRPH_TASK_LINK__:{node_name}</font>'
+    )
+    if label:
+        label = "<" + task_link_line + '<br align="left"/>' + label[1:]
+    else:
+        label = "<" + task_link_line + '<br align="left"/>' + ">"
+
+    if order_by_date:
+        lines.append(
+            f"{indent}{node_name} [label={label},"
+            f" sortv={sort_order[node_name]}];"
         )
     else:
-        label = ""
-    if label:
-        if order_by_date:
-            lines.append(
-                f"{indent}{node_name} [label={label},"
-                f" sortv={sort_order[node_name]}];"
-            )
-        else:
-            lines.append(f"{indent}{node_name} [label={label}];")
-    else:
-        if order_by_date:
-            lines.append(
-                f"{indent}{node_name} [sortv={sort_order[node_name]}];"
-            )
-        else:
-            lines.append(f"{indent}{node_name};")
+        lines.append(f"{indent}{node_name} [label={label}];")
 
 
 def yaml_to_dot(data, wrap_width=55, order_by_date=False):

--- a/pydifftools/flowchart/graph.py
+++ b/pydifftools/flowchart/graph.py
@@ -380,7 +380,9 @@ def _append_node(
 ):
     # Every rendered DOT node corresponds to a real YAML node, so build the
     # label directly from that node and prepend the task-link marker line.
-    label = _node_label(_node_text_with_due(data["nodes"][node_name]), wrap_width)
+    label = _node_label(
+        _node_text_with_due(data["nodes"][node_name]), wrap_width
+    )
     task_link_line = (
         f'<font point-size="7">__WGRPH_TASK_LINK__:{node_name}</font>'
     )
@@ -644,10 +646,7 @@ def write_dot_from_yaml(
             if parent in ancestors:
                 continue
             ancestors.add(parent)
-            if (
-                parent in data["nodes"]
-                and "parents" in data["nodes"][parent]
-            ):
+            if parent in data["nodes"] and "parents" in data["nodes"][parent]:
                 for grandparent in data["nodes"][parent]["parents"]:
                     parents_to_check.append(grandparent)
         incomplete_ancestors = set()

--- a/pydifftools/flowchart/watch_graph.py
+++ b/pydifftools/flowchart/watch_graph.py
@@ -814,18 +814,21 @@ def wgrph(yaml, wrap_width=55, d=False, t=None):
     observer = Observer()
     observer.schedule(event_handler, yaml_file.parent, recursive=False)
     observer.start()
+    dead_since = None
     try:
         while True:
             preview_server.serve_pending_request()
-            # Exit the watcher when the browser window is closed so the CLI
-            # process does not stay alive in the background.
-            # Navigation between / and /?t=... can briefly report liveness
-            # errors while Chrome swaps documents. Require two consecutive dead
-            # checks so click navigation is not mistaken for a closed window.
-            if not browser_window_is_alive(event_handler.driver):
-                time.sleep(0.2)
-                if not browser_window_is_alive(event_handler.driver):
+            # Exit the watcher when the browser window is really closed, but
+            # tolerate short Selenium liveness errors during top-level
+            # navigation (for example when opening /?t=... from the links).
+            if browser_window_is_alive(event_handler.driver):
+                dead_since = None
+            else:
+                if dead_since is None:
+                    dead_since = time.time()
+                elif time.time() - dead_since >= 1.0:
                     break
+            time.sleep(0.1)
     except KeyboardInterrupt:
         pass
     finally:

--- a/pydifftools/flowchart/watch_graph.py
+++ b/pydifftools/flowchart/watch_graph.py
@@ -2,9 +2,9 @@ import subprocess
 import time
 import shutil
 import math
+import threading
 import urllib.parse
 import http.server
-import socketserver
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -630,6 +630,7 @@ class FlowchartPreviewServer:
         self.event_handler = event_handler
         self.host = host
         self.httpd = None
+        self.server_thread = None
         self.base_url = None
         self.svg_url = None
         self.date_ordered_url = None
@@ -706,22 +707,31 @@ class FlowchartPreviewServer:
             def log_message(self, format, *args):
                 return
 
-        self.httpd = socketserver.TCPServer((self.host, 0), Handler)
-        # Run request handling in the main watcher loop. A short timeout keeps
-        # the CLI responsive while still serving GET requests quickly.
-        self.httpd.timeout = 0.25
+        self.httpd = http.server.ThreadingHTTPServer((self.host, 0), Handler)
+        self.httpd.daemon_threads = True
         port = self.httpd.server_address[1]
         self.base_url = f"http://{self.host}:{port}/"
         self.svg_url = f"http://{self.host}:{port}/graph.svg"
         self.date_ordered_url = f"http://{self.host}:{port}/?d=1"
+        # Start serving immediately so the first browser navigation does not
+        # block waiting for the watcher loop to call handle_request.
+        self.server_thread = threading.Thread(
+            target=self.httpd.serve_forever,
+            daemon=True,
+        )
+        self.server_thread.start()
 
     def serve_pending_request(self):
-        if self.httpd is not None:
-            self.httpd.handle_request()
+        # The server runs in a background thread; this method remains for
+        # compatibility with the watcher loop call site.
+        return
 
     def stop(self):
         if self.httpd is not None:
+            self.httpd.shutdown()
             self.httpd.server_close()
+        if self.server_thread is not None:
+            self.server_thread.join(timeout=1.0)
 
 
 

--- a/pydifftools/flowchart/watch_graph.py
+++ b/pydifftools/flowchart/watch_graph.py
@@ -240,7 +240,8 @@ def _watch_html(svg_url, order_by_date):
         footer_url = "/"
     return (
         "<html><body style='margin:0'>"
-        f"<embed id='svg-view' style='display:block;' type='image/svg+xml' src='{svg_url}'/>"
+        "<embed id='svg-view' style='display:block;' type='image/svg+xml'"
+        f" src='{svg_url}'/>"
         "<p style='margin:0.4em 0.8em;font-family:sans-serif;font-size:13px;'>"
         f"<a href='{footer_url}'>{footer_label}</a>"
         "</p>"
@@ -284,7 +285,6 @@ def _svg_expanded_outline(
     )
 
 
-
 def _svg_add_task_links(svg_root, namespace):
     # Replace marker text emitted in DOT labels with clickable links. Graphviz
     # generates one <text> item per line, so the marker occupies its own row.
@@ -302,12 +302,13 @@ def _svg_add_task_links(svg_root, namespace):
             task_name = child.text[len(link_marker) :]
             child.text = task_name
             link = ET.Element(f"{namespace}a")
-            link.set(f"{{{xlink_ns}}}href", f"/?t={urllib.parse.quote(task_name)}")
+            link.set(
+                f"{{{xlink_ns}}}href", f"/?t={urllib.parse.quote(task_name)}"
+            )
             link.set("target", "_top")
             link.append(child)
             group.remove(child)
             group.insert(index, link)
-
 
 
 def build_graph(
@@ -699,7 +700,9 @@ class FlowchartPreviewServer:
                         event_handler.state["target_task"],
                     )
 
-                body = _watch_html("/graph.svg", event_handler.state["order_by_date"])
+                body = _watch_html(
+                    "/graph.svg", event_handler.state["order_by_date"]
+                )
                 body_bytes = body.encode("utf-8")
                 self.send_response(200)
                 self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -737,7 +740,6 @@ class FlowchartPreviewServer:
             self.server_thread.join(timeout=1.0)
 
 
-
 @register_command(
     "Watch a flowchart YAML file, rebuild DOT/SVG output, and open the"
     " preview",
@@ -745,7 +747,7 @@ class FlowchartPreviewServer:
         "yaml": "Path to the flowchart YAML file",
         "wrap_width": "Line wrap width used when generating node labels",
         "d": "Render nodes by date without showing connections",
-        "t": ("Task name to focus on (show incomplete ancestor tasks only)"),
+        "t": "Task name to focus on (show incomplete ancestor tasks only)",
     },
 )
 def wgrph(yaml, wrap_width=55, d=False, t=None):
@@ -807,7 +809,11 @@ def wgrph(yaml, wrap_width=55, d=False, t=None):
     event_handler.driver = driver
 
     if t is not None and str(t).strip():
-        driver.get(preview_server.base_url + "?t=" + urllib.parse.quote(str(t).strip()))
+        driver.get(
+            preview_server.base_url
+            + "?t="
+            + urllib.parse.quote(str(t).strip())
+        )
     elif d:
         driver.get(preview_server.base_url + "?d=1")
 

--- a/pydifftools/flowchart/watch_graph.py
+++ b/pydifftools/flowchart/watch_graph.py
@@ -2,6 +2,9 @@ import subprocess
 import time
 import shutil
 import math
+import urllib.parse
+import http.server
+import socketserver
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -24,12 +27,19 @@ from pydifftools.browser_lifecycle import (
 from .graph import write_dot_from_yaml
 
 
-def _reload_svg(driver, svg_file: Path) -> None:
+def _reload_svg(driver, svg_src) -> None:
     """Refresh the embedded SVG while preserving zoom and scroll."""
     zoom = driver.execute_script("return window.visualViewport.scale")
     scroll_x = driver.execute_script("return window.scrollX")
     scroll_y = driver.execute_script("return window.scrollY")
-    svg_uri = svg_file.resolve().as_uri() + f"?t={time.time()}"
+    if isinstance(svg_src, Path):
+        svg_uri = svg_src.resolve().as_uri()
+    else:
+        svg_uri = str(svg_src)
+    if "?" in svg_uri:
+        svg_uri = svg_uri + f"&ts={time.time()}"
+    else:
+        svg_uri = svg_uri + f"?ts={time.time()}"
     driver.execute_async_script(
         "const [src,z,x,y,done]=arguments;const"
         " s=document.getElementById('svg-view');s.onload=function()"
@@ -42,10 +52,10 @@ def _reload_svg(driver, svg_file: Path) -> None:
     )
 
 
-def start_chrome(webdriver, options, html_file):
-    # Launch Chrome and display the local SVG preview HTML file.
+def start_chrome(webdriver, options, preview_url):
+    # Launch Chrome and display the local SVG preview page from the server.
     driver = webdriver.Chrome(options=options)
-    driver.get(html_file.resolve().as_uri())
+    driver.get(preview_url)
     return driver
 
 
@@ -219,11 +229,17 @@ def _svg_add_canvas_padding(svg_root, padding=8.0):
     )
 
 
-def _watch_html(svg_file):
+def _watch_html(svg_url, date_ordered_url):
+    # The local preview page points the embed to a server URL so query-string
+    # toggles (?t=... and ?d=1) can trigger server-side graph rebuilds.
     return (
-        "<html><body style='margin:0'><embed id='svg-view'"
-        " style='display:block;' type='image/svg+xml'"
-        f" src='{svg_file.name}?t={time.time()}'/></body></html>"
+        "<html><body style='margin:0'>"
+        "<embed id='svg-view' style='display:block;width:100%;height:calc(100vh - 2.2em);'"
+        f" type='image/svg+xml' src='{svg_url}'/>"
+        "<p style='margin:0.4em 0.8em;font-family:sans-serif;font-size:13px;'>"
+        f"<a href='{date_ordered_url}'>date-ordered</a>"
+        "</p>"
+        "</body></html>"
     )
 
 
@@ -263,6 +279,32 @@ def _svg_expanded_outline(
     )
 
 
+
+def _svg_add_task_links(svg_root, namespace):
+    # Replace marker text emitted in DOT labels with clickable links. Graphviz
+    # generates one <text> item per line, so the marker occupies its own row.
+    xlink_ns = "http://www.w3.org/1999/xlink"
+    ET.register_namespace("xlink", xlink_ns)
+    link_marker = "__WGRPH_TASK_LINK__:"
+    for group in svg_root.iter(f"{namespace}g"):
+        if "class" not in group.attrib or group.attrib["class"] != "node":
+            continue
+        for index, child in enumerate(list(group)):
+            if child.tag != f"{namespace}text" or child.text is None:
+                continue
+            if not child.text.startswith(link_marker):
+                continue
+            task_name = child.text[len(link_marker) :]
+            child.text = task_name
+            link = ET.Element(f"{namespace}a")
+            link.set(f"{{{xlink_ns}}}href", f"/?t={urllib.parse.quote(task_name)}")
+            link.set("target", "_top")
+            link.append(child)
+            group.remove(child)
+            group.insert(index, link)
+
+
+
 def build_graph(
     yaml_file,
     dot_file,
@@ -296,6 +338,8 @@ def build_graph(
     namespace = ""
     if svg_root.tag.startswith("{"):
         namespace = svg_root.tag[: svg_root.tag.find("}") + 1]
+
+    _svg_add_task_links(svg_root, namespace)
 
     if not order_by_date:
         # In dependency view mode, each node explicitly tagged with
@@ -502,27 +546,30 @@ class GraphEventHandler(FileSystemEventHandler):
         yaml_file,
         dot_file,
         svg_file,
-        html_file=None,
+        preview_url=None,
+        svg_url=None,
         driver=None,
         options=None,
         webdriver=None,
         wrap_width=55,
         data=None,
-        order_by_date=False,
-        target_task=None,
+        state=None,
         debounce=0.25,
     ):
         self.yaml_file = Path(yaml_file)
         self.dot_file = Path(dot_file)
         self.svg_file = Path(svg_file)
-        self.html_file = None if html_file is None else Path(html_file)
+        self.preview_url = preview_url
+        self.svg_url = svg_url
         self.driver = driver
         self.options = options
         self.webdriver = webdriver
         self.wrap_width = wrap_width
         self.data = data
-        self.order_by_date = order_by_date
-        self.target_task = target_task
+        if state is None:
+            self.state = {"order_by_date": False, "target_task": None}
+        else:
+            self.state = state
         self.debounce = debounce
         self._last_handled = 0.0
         self._last_mtime = None
@@ -542,9 +589,9 @@ class GraphEventHandler(FileSystemEventHandler):
                     self.dot_file,
                     self.svg_file,
                     self.wrap_width,
-                    self.order_by_date,
+                    self.state["order_by_date"],
                     self.data,
-                    self.target_task,
+                    self.state["target_task"],
                 )
             except Exception:
                 # If the graph fails to build (e.g. invalid date), close the
@@ -558,19 +605,124 @@ class GraphEventHandler(FileSystemEventHandler):
                 if (
                     self.webdriver is not None
                     and self.options is not None
-                    and self.html_file is not None
+                    and self.preview_url is not None
                 ):
                     self.driver = start_chrome(
-                        self.webdriver, self.options, self.html_file
+                        self.webdriver, self.options, self.preview_url
                     )
                 else:
-                    # Allow legacy/test usage without a live driver.
-                    _reload_svg(self.driver, self.svg_file)
+                    # Allow test/legacy usage where no browser driver exists.
+                    if self.svg_url is not None:
+                        _reload_svg(self.driver, self.svg_url)
+                    else:
+                        _reload_svg(self.driver, self.svg_file)
                     self._last_mtime = self.yaml_file.stat().st_mtime
                     return
+            if self.svg_url is not None:
+                _reload_svg(self.driver, self.svg_url)
             else:
                 _reload_svg(self.driver, self.svg_file)
             self._last_mtime = self.yaml_file.stat().st_mtime
+
+
+class FlowchartPreviewServer:
+    def __init__(self, event_handler, host="127.0.0.1"):
+        self.event_handler = event_handler
+        self.host = host
+        self.httpd = None
+        self.base_url = None
+        self.svg_url = None
+        self.date_ordered_url = None
+
+    def start(self):
+        event_handler = self.event_handler
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                parsed = urllib.parse.urlparse(self.path)
+                if parsed.path == "/graph.svg":
+                    svg_bytes = event_handler.svg_file.read_bytes()
+                    self.send_response(200)
+                    self.send_header(
+                        "Content-Type", "image/svg+xml; charset=utf-8"
+                    )
+                    self.send_header("Cache-Control", "no-store")
+                    self.end_headers()
+                    self.wfile.write(svg_bytes)
+                    return
+
+                if parsed.path != "/" and parsed.path != "/index.html":
+                    self.send_error(404)
+                    return
+
+                # Parse query args so GET requests control graph mode.
+                params = urllib.parse.parse_qs(
+                    parsed.query, keep_blank_values=True
+                )
+                order_by_date = event_handler.state["order_by_date"]
+                target_task = event_handler.state["target_task"]
+                if "d" in params:
+                    d_value = params["d"][-1]
+                    order_by_date = d_value in (
+                        "1",
+                        "true",
+                        "yes",
+                        "on",
+                        "",
+                    )
+                if "t" in params:
+                    t_value = params["t"][-1].strip()
+                    if t_value:
+                        target_task = t_value
+                        order_by_date = False
+                    else:
+                        target_task = None
+
+                if (
+                    order_by_date != event_handler.state["order_by_date"]
+                    or target_task != event_handler.state["target_task"]
+                ):
+                    event_handler.state["order_by_date"] = order_by_date
+                    event_handler.state["target_task"] = target_task
+                    event_handler.data = build_graph(
+                        event_handler.yaml_file,
+                        event_handler.dot_file,
+                        event_handler.svg_file,
+                        event_handler.wrap_width,
+                        event_handler.state["order_by_date"],
+                        event_handler.data,
+                        event_handler.state["target_task"],
+                    )
+
+                body = _watch_html("/graph.svg", "/?d=1")
+                body_bytes = body.encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body_bytes)))
+                self.send_header("Cache-Control", "no-store")
+                self.end_headers()
+                self.wfile.write(body_bytes)
+
+            def log_message(self, format, *args):
+                return
+
+        self.httpd = socketserver.TCPServer((self.host, 0), Handler)
+        # Run request handling in the main watcher loop. A short timeout keeps
+        # the CLI responsive while still serving GET requests quickly.
+        self.httpd.timeout = 0.25
+        port = self.httpd.server_address[1]
+        self.base_url = f"http://{self.host}:{port}/"
+        self.svg_url = f"http://{self.host}:{port}/graph.svg"
+        self.date_ordered_url = f"http://{self.host}:{port}/?d=1"
+
+    def serve_pending_request(self):
+        if self.httpd is not None:
+            self.httpd.handle_request()
+
+    def stop(self):
+        if self.httpd is not None:
+            self.httpd.server_close()
+
 
 
 @register_command(
@@ -602,41 +754,64 @@ def wgrph(yaml, wrap_width=55, d=False, t=None):
 
     dot_file = yaml_file.with_suffix(".dot")
     svg_file = yaml_file.with_suffix(".svg")
-    html_file = yaml_file.with_suffix(".html")
 
-    # Use date ordering when requested so boxes appear in calendar order.
-    # Render the initial graph, optionally restricting to incomplete ancestors
-    # of a target task.
-    data = build_graph(yaml_file, dot_file, svg_file, wrap_width, d, None, t)
-    html_file.write_text(_watch_html(svg_file))
+    # The browser now drives filtering/date-mode by GET query parameters
+    # handled by the local preview server. Keep Python state in sync there.
+    initial_state = {"order_by_date": False, "target_task": None}
+
+    # Build the default dependency graph first. Optional -t / -d args are then
+    # applied by requesting server URLs with query parameters.
+    data = build_graph(
+        yaml_file,
+        dot_file,
+        svg_file,
+        wrap_width,
+        initial_state["order_by_date"],
+        None,
+        initial_state["target_task"],
+    )
+
     options = Options()
-    driver = start_chrome(webdriver, options, html_file)
     event_handler = GraphEventHandler(
         yaml_file,
         dot_file,
         svg_file,
-        html_file,
-        driver,
+        None,
+        None,
+        None,
         options,
         webdriver,
         wrap_width,
         data,
-        d,
-        t,
+        initial_state,
     )
+    preview_server = FlowchartPreviewServer(event_handler)
+    preview_server.start()
+    event_handler.preview_url = preview_server.base_url
+    event_handler.svg_url = preview_server.svg_url
+
+    driver = start_chrome(webdriver, options, preview_server.base_url)
+    event_handler.driver = driver
+
+    if t is not None and str(t).strip():
+        driver.get(preview_server.base_url + "?t=" + urllib.parse.quote(str(t).strip()))
+    elif d:
+        driver.get(preview_server.base_url + "?d=1")
+
     observer = Observer()
     observer.schedule(event_handler, yaml_file.parent, recursive=False)
     observer.start()
     try:
         while True:
+            preview_server.serve_pending_request()
             # Exit the watcher when the browser window is closed so the CLI
             # process does not stay alive in the background.
             if not browser_window_is_alive(event_handler.driver):
                 break
-            time.sleep(1)
     except KeyboardInterrupt:
         pass
     finally:
         observer.stop()
         observer.join()
         close_chrome(event_handler.driver)
+        preview_server.stop()

--- a/pydifftools/flowchart/watch_graph.py
+++ b/pydifftools/flowchart/watch_graph.py
@@ -229,15 +229,20 @@ def _svg_add_canvas_padding(svg_root, padding=8.0):
     )
 
 
-def _watch_html(svg_url, date_ordered_url):
-    # The local preview page points the embed to a server URL so query-string
-    # toggles (?t=... and ?d=1) can trigger server-side graph rebuilds.
+def _watch_html(svg_url, order_by_date):
+    # Keep the SVG as the page's main content so browser zoom behavior matches
+    # the original watcher experience (the graph scales, not just footer text).
+    # The footer link toggles between dependency/date views depending on mode.
+    footer_label = "date-ordered"
+    footer_url = "/?d=1"
+    if order_by_date:
+        footer_label = "dependency-ordered"
+        footer_url = "/"
     return (
         "<html><body style='margin:0'>"
-        "<embed id='svg-view' style='display:block;width:100%;height:calc(100vh - 2.2em);'"
-        f" type='image/svg+xml' src='{svg_url}'/>"
+        f"<embed id='svg-view' style='display:block;' type='image/svg+xml' src='{svg_url}'/>"
         "<p style='margin:0.4em 0.8em;font-family:sans-serif;font-size:13px;'>"
-        f"<a href='{date_ordered_url}'>date-ordered</a>"
+        f"<a href='{footer_url}'>{footer_label}</a>"
         "</p>"
         "</body></html>"
     )
@@ -633,7 +638,6 @@ class FlowchartPreviewServer:
         self.server_thread = None
         self.base_url = None
         self.svg_url = None
-        self.date_ordered_url = None
 
     def start(self):
         event_handler = self.event_handler
@@ -695,7 +699,7 @@ class FlowchartPreviewServer:
                         event_handler.state["target_task"],
                     )
 
-                body = _watch_html("/graph.svg", "/?d=1")
+                body = _watch_html("/graph.svg", event_handler.state["order_by_date"])
                 body_bytes = body.encode("utf-8")
                 self.send_response(200)
                 self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -712,7 +716,6 @@ class FlowchartPreviewServer:
         port = self.httpd.server_address[1]
         self.base_url = f"http://{self.host}:{port}/"
         self.svg_url = f"http://{self.host}:{port}/graph.svg"
-        self.date_ordered_url = f"http://{self.host}:{port}/?d=1"
         # Start serving immediately so the first browser navigation does not
         # block waiting for the watcher loop to call handle_request.
         self.server_thread = threading.Thread(
@@ -816,8 +819,13 @@ def wgrph(yaml, wrap_width=55, d=False, t=None):
             preview_server.serve_pending_request()
             # Exit the watcher when the browser window is closed so the CLI
             # process does not stay alive in the background.
+            # Navigation between / and /?t=... can briefly report liveness
+            # errors while Chrome swaps documents. Require two consecutive dead
+            # checks so click navigation is not mistaken for a closed window.
             if not browser_window_is_alive(event_handler.driver):
-                break
+                time.sleep(0.2)
+                if not browser_window_is_alive(event_handler.driver):
+                    break
     except KeyboardInterrupt:
         pass
     finally:

--- a/tests/flowchart/sample.dot
+++ b/tests/flowchart/sample.dot
@@ -12,16 +12,16 @@ digraph G {
     node [shape=box,width=0.5];
     subgraph group1 {
         node [color=blue, fontcolor=blue];
-        Start [label=<Begin process
+        Start [label=<<font point-size="7">__WGRPH_TASK_LINK__:Start</font><br align="left"/>Begin process
 <br align="left"/>
 • item1
 <br align="left"/>
 • item2
 <br align="left"/>>];
     };
-    Middle [label=<Continue
+    Middle [label=<<font point-size="7">__WGRPH_TASK_LINK__:Middle</font><br align="left"/>Continue
 <br align="left"/>>];
-    End [label=<Finish
+    End [label=<<font point-size="7">__WGRPH_TASK_LINK__:End</font><br align="left"/>Finish
 <br align="left"/>
 <font color="orange">10/2/25</font>
 <br align="left"/>>];

--- a/tests/flowchart/test_due_dates.py
+++ b/tests/flowchart/test_due_dates.py
@@ -40,7 +40,10 @@ def test_due_dates_render():
         in dot
     )
     # Nodes that only declare a due date still render the value in orange.
-    assert '<font point-size="7">__WGRPH_TASK_LINK__:Alt</font><br align="left"/><font color="orange">3/4/26</font>' in dot
+    assert (
+        '<font point-size="7">__WGRPH_TASK_LINK__:Alt</font>'
+        '<br align="left"/><font color="orange">3/4/26</font>'
+    ) in dot
 
 
 def test_completed_due_is_green():

--- a/tests/flowchart/test_due_dates.py
+++ b/tests/flowchart/test_due_dates.py
@@ -40,7 +40,7 @@ def test_due_dates_render():
         in dot
     )
     # Nodes that only declare a due date still render the value in orange.
-    assert 'Alt [label=<<font color="orange">3/4/26</font>' in dot
+    assert '<font point-size="7">__WGRPH_TASK_LINK__:Alt</font><br align="left"/><font color="orange">3/4/26</font>' in dot
 
 
 def test_completed_due_is_green():

--- a/tests/flowchart/test_list_indentation.py
+++ b/tests/flowchart/test_list_indentation.py
@@ -27,8 +27,8 @@ def test_bullet_overflow_indent(tmp_path):
     assert m, "label not found"
     label = m.group(1)
     segments = _extract_segments(label)
-    assert segments[0].startswith("• ")
-    assert segments[1].startswith("  ")
+    assert segments[1].startswith("• ")
+    assert segments[2].startswith("  ")
 
 
 def test_numbered_overflow_indent(tmp_path):
@@ -49,5 +49,5 @@ def test_numbered_overflow_indent(tmp_path):
     assert m, "label not found"
     label = m.group(1)
     segments = _extract_segments(label)
-    assert segments[0].startswith("1. ")
-    assert segments[1].startswith("  ")
+    assert segments[1].startswith("1. ")
+    assert segments[2].startswith("  ")

--- a/tests/flowchart/test_project_bubbles.py
+++ b/tests/flowchart/test_project_bubbles.py
@@ -25,7 +25,8 @@ def _node_border_shapes(group, namespace):
     return [
         child
         for child in group
-        if child.tag in (f"{namespace}polygon", f"{namespace}rect", f"{namespace}ellipse")
+        if child.tag
+        in (f"{namespace}polygon", f"{namespace}rect", f"{namespace}ellipse")
         and "stroke" in child.attrib
     ]
 
@@ -80,8 +81,7 @@ def test_build_graph_colors_node_borders_and_removes_bubbles(tmp_path):
     yaml_file = tmp_path / "graph.yaml"
     dot_file = tmp_path / "graph.dot"
     svg_file = tmp_path / "graph.svg"
-    yaml_file.write_text(
-        """
+    yaml_file.write_text("""
 nodes:
   root:
     text: Root
@@ -95,10 +95,11 @@ nodes:
   end2:
     text: End 2
     style: endpoint
-""".strip()
-    )
+""".strip())
 
-    build_graph(yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False)
+    build_graph(
+        yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False
+    )
 
     tree = ET.parse(svg_file)
     root = tree.getroot()
@@ -111,8 +112,12 @@ nodes:
         for group in root.iter(f"{namespace}g")
     )
 
-    end1_stroke = _node_border_shapes(nodes["end1"], namespace)[0].attrib["stroke"]
-    end2_stroke = _node_border_shapes(nodes["end2"], namespace)[0].attrib["stroke"]
+    end1_stroke = _node_border_shapes(nodes["end1"], namespace)[0].attrib[
+        "stroke"
+    ]
+    end2_stroke = _node_border_shapes(nodes["end2"], namespace)[0].attrib[
+        "stroke"
+    ]
 
     root_shapes = _node_border_shapes(nodes["root"], namespace)
     root_strokes = [shape.attrib["stroke"] for shape in root_shapes]
@@ -123,7 +128,8 @@ nodes:
     transparent_outlines = [
         shape
         for shape in root_shapes
-        if shape.tag == f"{namespace}rect" and shape.attrib.get("fill") == "none"
+        if shape.tag == f"{namespace}rect"
+        and shape.attrib.get("fill") == "none"
     ]
     assert transparent_outlines
 
@@ -132,8 +138,7 @@ def test_viewbox_contains_postprocessed_geometry(tmp_path):
     yaml_file = tmp_path / "graph.yaml"
     dot_file = tmp_path / "graph.dot"
     svg_file = tmp_path / "graph.svg"
-    yaml_file.write_text(
-        """
+    yaml_file.write_text("""
 nodes:
   bottom_left:
     text: Bottom Left
@@ -147,10 +152,11 @@ nodes:
   endpoint_b:
     text: Endpoint B
     style: endpoint
-""".strip()
-    )
+""".strip())
 
-    build_graph(yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False)
+    build_graph(
+        yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False
+    )
 
     tree = ET.parse(svg_file)
     root = tree.getroot()
@@ -181,7 +187,9 @@ nodes:
                 content_bounds, _bounds_from_points(element.attrib["points"])
             )
         elif element.tag == f"{namespace}rect":
-            content_bounds = _union_bounds(content_bounds, _rect_bounds(element))
+            content_bounds = _union_bounds(
+                content_bounds, _rect_bounds(element)
+            )
         elif element.tag == f"{namespace}ellipse":
             content_bounds = _union_bounds(
                 content_bounds, _ellipse_bounds(element)
@@ -202,8 +210,7 @@ def test_project_for_single_endpoint_colors_ancestors(tmp_path):
     yaml_file = tmp_path / "graph.yaml"
     dot_file = tmp_path / "graph.dot"
     svg_file = tmp_path / "graph.svg"
-    yaml_file.write_text(
-        """
+    yaml_file.write_text("""
 nodes:
   root:
     text: Root
@@ -214,19 +221,20 @@ nodes:
   child_endpoint:
     text: Child Endpoint
     style: endpoint
-""".strip()
-    )
+""".strip())
 
-    build_graph(yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False)
+    build_graph(
+        yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False
+    )
 
     tree = ET.parse(svg_file)
     root = tree.getroot()
     namespace = _svg_namespace(root)
     nodes = _node_groups_by_title(root, namespace)
 
-    endpoint_color = _node_border_shapes(nodes["child_endpoint"], namespace)[0].attrib[
-        "stroke"
-    ]
+    endpoint_color = _node_border_shapes(nodes["child_endpoint"], namespace)[
+        0
+    ].attrib["stroke"]
     for node_name in ("root", "middle"):
         border_shapes = _node_border_shapes(nodes[node_name], namespace)
         assert border_shapes[0].attrib["stroke"] == endpoint_color
@@ -236,8 +244,7 @@ def test_edge_color_comes_from_child_project(tmp_path):
     yaml_file = tmp_path / "graph.yaml"
     dot_file = tmp_path / "graph.dot"
     svg_file = tmp_path / "graph.svg"
-    yaml_file.write_text(
-        """
+    yaml_file.write_text("""
 nodes:
   left_endpoint:
     text: Left Endpoint
@@ -249,10 +256,11 @@ nodes:
   right_endpoint:
     text: Right Endpoint
     style: endpoint
-""".strip()
-    )
+""".strip())
 
-    build_graph(yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False)
+    build_graph(
+        yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False
+    )
 
     tree = ET.parse(svg_file)
     root = tree.getroot()
@@ -274,16 +282,19 @@ nodes:
             "left_endpoint",
             "right_endpoint",
         ):
-            node_colors[title] = _node_border_shapes(group, namespace)[0].attrib["stroke"]
+            node_colors[title] = _node_border_shapes(group, namespace)[
+                0
+            ].attrib["stroke"]
         if group.attrib["class"] == "edge" and title == "left_endpoint->mid":
             for child in group:
-                if child.tag == f"{namespace}path" and "stroke" in child.attrib:
+                if (
+                    child.tag == f"{namespace}path"
+                    and "stroke" in child.attrib
+                ):
                     edge_colors[title] = child.attrib["stroke"]
                     break
 
-    assert (
-        edge_colors["left_endpoint->mid"] == node_colors["right_endpoint"]
-    )
+    assert edge_colors["left_endpoint->mid"] == node_colors["right_endpoint"]
     assert edge_colors["left_endpoint->mid"] != node_colors["left_endpoint"]
 
 
@@ -291,8 +302,7 @@ def test_nonterminal_styled_endpoint_drives_project_coloring(tmp_path):
     yaml_file = tmp_path / "graph.yaml"
     dot_file = tmp_path / "graph.dot"
     svg_file = tmp_path / "graph.svg"
-    yaml_file.write_text(
-        """
+    yaml_file.write_text("""
 nodes:
   root:
     text: Root
@@ -303,39 +313,47 @@ nodes:
     children: [leaf]
   leaf:
     text: Plain Leaf
-""".strip()
-    )
+""".strip())
 
-    build_graph(yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False)
+    build_graph(
+        yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False
+    )
 
     tree = ET.parse(svg_file)
     root = tree.getroot()
     namespace = _svg_namespace(root)
     nodes = _node_groups_by_title(root, namespace)
 
-    hub_color = _node_border_shapes(nodes["hub"], namespace)[0].attrib["stroke"]
-    root_color = _node_border_shapes(nodes["root"], namespace)[0].attrib["stroke"]
-    leaf_color = _node_border_shapes(nodes["leaf"], namespace)[0].attrib["stroke"]
+    hub_color = _node_border_shapes(nodes["hub"], namespace)[0].attrib[
+        "stroke"
+    ]
+    root_color = _node_border_shapes(nodes["root"], namespace)[0].attrib[
+        "stroke"
+    ]
+    leaf_color = _node_border_shapes(nodes["leaf"], namespace)[0].attrib[
+        "stroke"
+    ]
 
     assert hub_color == root_color
     assert leaf_color != hub_color
+
 
 def test_build_graph_adds_task_links_to_all_nodes(tmp_path):
     yaml_file = tmp_path / "graph.yaml"
     dot_file = tmp_path / "graph.dot"
     svg_file = tmp_path / "graph.svg"
-    yaml_file.write_text(
-        """
+    yaml_file.write_text("""
 nodes:
   first_task:
     text: First Task
     children: [second_task]
   second_task:
     text: Second Task
-""".strip()
-    )
+""".strip())
 
-    build_graph(yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False)
+    build_graph(
+        yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False
+    )
 
     tree = ET.parse(svg_file)
     root = tree.getroot()

--- a/tests/flowchart/test_project_bubbles.py
+++ b/tests/flowchart/test_project_bubbles.py
@@ -319,3 +319,34 @@ nodes:
 
     assert hub_color == root_color
     assert leaf_color != hub_color
+
+def test_build_graph_adds_task_links_to_all_nodes(tmp_path):
+    yaml_file = tmp_path / "graph.yaml"
+    dot_file = tmp_path / "graph.dot"
+    svg_file = tmp_path / "graph.svg"
+    yaml_file.write_text(
+        """
+nodes:
+  first_task:
+    text: First Task
+    children: [second_task]
+  second_task:
+    text: Second Task
+""".strip()
+    )
+
+    build_graph(yaml_file, dot_file, svg_file, wrap_width=55, order_by_date=False)
+
+    tree = ET.parse(svg_file)
+    root = tree.getroot()
+    namespace = _svg_namespace(root)
+    links = list(root.iter(f"{namespace}a"))
+
+    hrefs = []
+    for link in links:
+        for attr_name in link.attrib:
+            if attr_name.endswith("}href"):
+                hrefs.append(link.attrib[attr_name])
+
+    assert "/?t=first_task" in hrefs
+    assert "/?t=second_task" in hrefs

--- a/tests/flowchart/test_watch_reload.py
+++ b/tests/flowchart/test_watch_reload.py
@@ -52,3 +52,87 @@ def test_watch_html_uses_block_embed(tmp_path):
     assert "id='svg-view'" in html
     assert "type='image/svg+xml'" in html
     assert "<a href='/?d=1'>date-ordered</a>" in html
+
+
+class FakeObserver:
+    def __init__(self):
+        self.stopped = False
+        self.joined = False
+
+    def schedule(self, handler, path, recursive=False):
+        self.handler = handler
+        self.path = path
+        self.recursive = recursive
+
+    def start(self):
+        return
+
+    def stop(self):
+        self.stopped = True
+
+    def join(self):
+        self.joined = True
+
+
+class FakePreviewServer:
+    latest = None
+
+    def __init__(self, event_handler):
+        self.event_handler = event_handler
+        self.base_url = "http://127.0.0.1:9999/"
+        self.svg_url = "http://127.0.0.1:9999/graph.svg"
+        self.started = False
+        self.stopped = False
+        self.served = 0
+        FakePreviewServer.latest = self
+
+    def start(self):
+        self.started = True
+
+    def serve_pending_request(self):
+        self.served += 1
+
+    def stop(self):
+        self.stopped = True
+
+
+def test_wgrph_stops_preview_server_when_browser_window_closed(tmp_path, monkeypatch):
+    # Build a minimal yaml graph for the command to read.
+    yaml_file = tmp_path / "graph.yaml"
+    yaml_file.write_text("nodes:\n  task_a:\n    text: Task A\n")
+
+    close_calls = []
+
+    # Replace expensive components so the command loop can run as a fast
+    # unit test.
+    monkeypatch.setattr(
+        "pydifftools.flowchart.watch_graph.build_graph",
+        lambda *args, **kwargs: {"nodes": {"task_a": {"text": "Task A"}}},
+    )
+    monkeypatch.setattr(
+        "pydifftools.flowchart.watch_graph.start_chrome",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "pydifftools.flowchart.watch_graph.browser_window_is_alive",
+        lambda _driver: False,
+    )
+    monkeypatch.setattr(
+        "pydifftools.flowchart.watch_graph.close_chrome",
+        close_calls.append,
+    )
+    monkeypatch.setattr("pydifftools.flowchart.watch_graph.Observer", FakeObserver)
+    monkeypatch.setattr(
+        "pydifftools.flowchart.watch_graph.FlowchartPreviewServer",
+        FakePreviewServer,
+    )
+
+    from pydifftools.flowchart.watch_graph import wgrph
+
+    wgrph(str(yaml_file))
+
+    # The browser shutdown path must also stop the local preview server.
+    assert FakePreviewServer.latest is not None
+    assert FakePreviewServer.latest.started is True
+    assert FakePreviewServer.latest.stopped is True
+    assert len(close_calls) == 1

--- a/tests/flowchart/test_watch_reload.py
+++ b/tests/flowchart/test_watch_reload.py
@@ -46,8 +46,9 @@ def test_reload_preserves_view(tmp_path):
 
 def test_watch_html_uses_block_embed(tmp_path):
     svg_file = tmp_path / "graph.svg"
-    html = _watch_html(svg_file)
+    html = _watch_html("/graph.svg", "/?d=1")
     assert "<body style='margin:0'>" in html
-    assert "style='display:block;'" in html
+    assert "style='display:block;width:100%;height:calc(100vh - 2.2em);'" in html
     assert "id='svg-view'" in html
     assert "type='image/svg+xml'" in html
+    assert "<a href='/?d=1'>date-ordered</a>" in html

--- a/tests/flowchart/test_watch_reload.py
+++ b/tests/flowchart/test_watch_reload.py
@@ -10,7 +10,6 @@ from selenium.webdriver.chrome.service import Service
 
 
 def test_reload_preserves_view(tmp_path):
-
     dot_file = tmp_path / "graph.dot"
     svg_file = tmp_path / "graph.svg"
     html_file = tmp_path / "view.html"
@@ -45,7 +44,6 @@ def test_reload_preserves_view(tmp_path):
 
 
 def test_watch_html_uses_block_embed(tmp_path):
-    svg_file = tmp_path / "graph.svg"
     html = _watch_html("/graph.svg", False)
     assert "<body style='margin:0'>" in html
     assert "style='display:block;'" in html
@@ -101,7 +99,9 @@ class FakePreviewServer:
         self.stopped = True
 
 
-def test_wgrph_stops_preview_server_when_browser_window_closed(tmp_path, monkeypatch):
+def test_wgrph_stops_preview_server_when_browser_window_closed(
+    tmp_path, monkeypatch
+):
     # Build a minimal yaml graph for the command to read.
     yaml_file = tmp_path / "graph.yaml"
     yaml_file.write_text("nodes:\n  task_a:\n    text: Task A\n")
@@ -126,7 +126,9 @@ def test_wgrph_stops_preview_server_when_browser_window_closed(tmp_path, monkeyp
         "pydifftools.flowchart.watch_graph.close_chrome",
         close_calls.append,
     )
-    monkeypatch.setattr("pydifftools.flowchart.watch_graph.Observer", FakeObserver)
+    monkeypatch.setattr(
+        "pydifftools.flowchart.watch_graph.Observer", FakeObserver
+    )
     monkeypatch.setattr(
         "pydifftools.flowchart.watch_graph.FlowchartPreviewServer",
         FakePreviewServer,

--- a/tests/flowchart/test_watch_reload.py
+++ b/tests/flowchart/test_watch_reload.py
@@ -46,12 +46,17 @@ def test_reload_preserves_view(tmp_path):
 
 def test_watch_html_uses_block_embed(tmp_path):
     svg_file = tmp_path / "graph.svg"
-    html = _watch_html("/graph.svg", "/?d=1")
+    html = _watch_html("/graph.svg", False)
     assert "<body style='margin:0'>" in html
-    assert "style='display:block;width:100%;height:calc(100vh - 2.2em);'" in html
+    assert "style='display:block;'" in html
     assert "id='svg-view'" in html
     assert "type='image/svg+xml'" in html
     assert "<a href='/?d=1'>date-ordered</a>" in html
+
+
+def test_watch_html_shows_dependency_link_in_date_mode():
+    html = _watch_html("/graph.svg", True)
+    assert "<a href='/'>dependency-ordered</a>" in html
 
 
 class FakeObserver:

--- a/tests/test_browser_lifecycle.py
+++ b/tests/test_browser_lifecycle.py
@@ -2,16 +2,10 @@ from pydifftools import browser_lifecycle
 
 
 class FakeBrowser:
-    def __init__(self, handles=None, script_error=False, quit_error=False):
+    def __init__(self, handles=None, quit_error=False):
         self.window_handles = handles if handles is not None else ["main"]
-        self.script_error = script_error
         self.quit_error = quit_error
         self.quit_calls = 0
-
-    def execute_script(self, _code):
-        if self.script_error:
-            raise RuntimeError("window closed")
-        return 1
 
     def quit(self):
         self.quit_calls += 1
@@ -26,11 +20,6 @@ def test_browser_window_is_alive_true():
 
 def test_browser_window_is_alive_false_when_handles_missing():
     browser = FakeBrowser(handles=[])
-    assert not browser_lifecycle.browser_window_is_alive(browser)
-
-
-def test_browser_window_is_alive_false_when_script_errors():
-    browser = FakeBrowser(script_error=True)
     assert not browser_lifecycle.browser_window_is_alive(browser)
 
 


### PR DESCRIPTION
### Motivation
- Make rendered flowchart nodes clickable so users can focus a task via the preview UI. 
- Support interactive preview controls (date-ordered view and task focus) driven by browser GET parameters rather than restarting the watcher. 
- Improve reload behavior to accept both local files and served URLs and preserve viewport when reloading the inline SVG. 

### Description
- Prepend a hidden task-link marker into every DOT node label in `graph._append_node` using `__WGRPH_TASK_LINK__:{node_name}` so the SVG post-processor can convert it into a link. 
- Add `_svg_add_task_links` which replaces the marker text in the emitted SVG with an `<a xlink:href="/?t=...">` wrapper so nodes become clickable targets that set `t` (task) in the preview. 
- Integrate `_svg_add_task_links` into `build_graph` so generated SVGs include the link elements. 
- Generalize `_reload_svg` to accept either a `Path` or a served URL string and append a timestamp query parameter as `ts` to force reloads. 
- Replace the static embedded HTML preview with a compact preview server implemented by `FlowchartPreviewServer` that serves `/graph.svg` and an index which parses `?d=1` (date mode) and `?t=...` (task focus) query parameters. 
- Update `GraphEventHandler` to keep mutable `state` (`order_by_date` and `target_task`) and use the preview server URLs for reloading; adjust driver/start logic to use `preview_url` and `svg_url`. 
- Update the `wgrph` command to start the preview server, wire `event_handler.preview_url`/`svg_url`, launch Chrome at the server URL, and apply initial `-d`/`-t` args via query parameters. 
- Update tests and sample DOT expected output to reflect the inserted task-link markup and new HTML/embed layout, and add `test_build_graph_adds_task_links_to_all_nodes`. 

### Testing
- Ran the flowchart unit tests affected by these changes: `test_due_dates`, `test_list_indentation`, `test_project_bubbles` (unchanged behavior plus new link assertions), `test_watch_reload`, and the new `test_build_graph_adds_task_links_to_all_nodes`, and all passed. 
- Verified the generated sample DOT now includes the `__WGRPH_TASK_LINK__` marker inside node labels as expected. 
- Exercised the preview server in the `wgrph` flow to ensure `?d=1` and `?t=...` requests toggle state and trigger a rebuild successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c26773a4832bbd523c4f3cd74183)