### PR TITLE
Add unified forward-search support for cpb and qmdb and improve `mfs` handling

### DIFF
--- a/pydifftools/browser_lifecycle.py
+++ b/pydifftools/browser_lifecycle.py
@@ -1,3 +1,7 @@
+import os
+import shutil
+import subprocess
+
 def browser_window_is_alive(browser):
     # Keep all browser liveness checks in one place so watch commands share
     # the same shutdown behavior when a user closes the browser window.
@@ -23,3 +27,42 @@ def close_browser_window(browser):
         browser.quit()
     except Exception:
         pass
+
+
+def forward_search_in_browser(browser, search_text):
+    # Reuse the same browser-side find logic across cpb and qmdb.
+    if browser is None or not search_text:
+        return False
+    found = browser.execute_script(
+        """
+        var searchText = arguments[0];
+        if (!window.find) {
+            return false;
+        }
+        var didFind = window.find(searchText);
+        if (didFind && window.getSelection) {
+            var selection = window.getSelection();
+            if (selection.rangeCount > 0) {
+                var rect = selection.getRangeAt(0).getBoundingClientRect();
+                window.scrollBy(0, rect.top - window.innerHeight / 3);
+            }
+        }
+        return didFind;
+        """,
+        search_text,
+    )
+    if not found:
+        print("forward search did not find text:", search_text)
+    # Bring the browser window to the foreground in Linux window managers.
+    if os.name == "posix" and shutil.which("wmctrl"):
+        window_title = browser.execute_script("return document.title;")
+        if window_title:
+            # Try common Chromium title forms used by desktop environments.
+            for title_candidate in [
+                window_title,
+                window_title + " - Google Chrome",
+                window_title + " - Chromium",
+                window_title + " - Chrome",
+            ]:
+                subprocess.run(["wmctrl", "-a", title_candidate], check=False)
+    return found

--- a/pydifftools/command_line.py
+++ b/pydifftools/command_line.py
@@ -30,7 +30,12 @@ from .rearrange_tex import run as rearrange_tex_run
 from .flowchart.watch_graph import wgrph
 from .flowchart.graph import load_graph_yaml
 from .notebook.tex_to_qmd import tex2qmd
-from .notebook.fast_build import qmdb, qmdinit
+from .notebook.fast_build import (
+    qmdb,
+    qmdinit,
+    QMDB_FORWARD_SEARCH_HOST,
+    QMDB_FORWARD_SEARCH_PORT,
+)
 
 from .command_registry import _COMMAND_SPECS, register_command
 
@@ -518,27 +523,48 @@ def fs(arguments):
     "markdown forward search, use with cpb to jump to text in the browser"
 )
 def mfs(text):
-    # Send the requested search text to the cpb socket listener.
-    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        client.connect((FORWARD_SEARCH_HOST, FORWARD_SEARCH_PORT))
-    except OSError as exc:
-        client.close()
-        # If cpb isn't running yet, choose a markdown file in this directory
-        # that contains the requested search text and start cpb for it.
+    # Normalize markdown-specific markup so search phrases match rendered text.
+    search_text = text
+    marker_match = re.search(r"(?i)@[a-z]{2,4}:", search_text)
+    if marker_match:
+        search_text = search_text[: marker_match.start()]
+    search_text = re.sub(r"\[@[^\]]+\]", " ", search_text)
+    search_text = search_text.replace("**", " ").replace("*", " ")
+    search_text = re.sub(r"\s+", " ", search_text).strip()
+    if not search_text:
+        search_text = text.strip()
+
+    # Try existing cpb and qmdb listeners before launching a new cpb process.
+    socket_addresses = [
+        (FORWARD_SEARCH_HOST, FORWARD_SEARCH_PORT),
+        (QMDB_FORWARD_SEARCH_HOST, QMDB_FORWARD_SEARCH_PORT),
+    ]
+    client = None
+    for address in socket_addresses:
+        candidate = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            candidate.connect(address)
+            client = candidate
+            break
+        except OSError:
+            candidate.close()
+    if client is None:
+        # If no listener is running yet, choose a markdown file in this
+        # directory that contains the requested search text and start cpb for
+        # it.
         matching_files = []
         for filename in sorted(os.listdir(".")):
             if not filename.endswith(".md"):
                 continue
             with open(filename, encoding="utf-8") as fp:
-                if text in fp.read():
+                if search_text in fp.read():
                     matching_files.append(filename)
         if len(matching_files) == 0:
             raise RuntimeError(
-                "Could not connect to cpb forward search socket and "
+                "Could not connect to cpb or qmdb forward search sockets and "
                 "could not find the requested text in any .md file in the "
                 "current directory."
-            ) from exc
+            )
         if len(matching_files) > 1:
             print(
                 "Found search text in multiple markdown files. "
@@ -554,19 +580,23 @@ def mfs(text):
         # Wait up to 20 seconds so the child can bring up the listener,
         # then resend the forward-search text.
         for _ in range(80):
-            client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                client.connect((FORWARD_SEARCH_HOST, FORWARD_SEARCH_PORT))
+            for address in socket_addresses:
+                candidate = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                try:
+                    candidate.connect(address)
+                    client = candidate
+                    break
+                except OSError:
+                    candidate.close()
+            if client is not None:
                 break
-            except OSError:
-                client.close()
-                time.sleep(0.25)
+            time.sleep(0.25)
         else:
             raise RuntimeError(
                 "Started cpb automatically, but the forward search socket "
                 "did not come up within 20 seconds."
             )
-    client.sendall(text.encode("utf-8"))
+    client.sendall(search_text.encode("utf-8"))
     client.close()
 
 

--- a/pydifftools/command_line.py
+++ b/pydifftools/command_line.py
@@ -875,9 +875,7 @@ def build_parser():
             # {{{ attach filename completer
             allowednames = argument.get("completion_allowednames")
             if FilesCompleter is not None and allowednames is not None:
-                action.completer = FilesCompleter(
-                    allowednames=allowednames
-                )
+                action.completer = FilesCompleter(allowednames=allowednames)
             # }}}
             if name == "wgrph" and action.dest == "t":
                 # Offer case-insensitive completions for incomplete task names.
@@ -885,6 +883,8 @@ def build_parser():
         subparser.set_defaults(_handler=spec["handler"])
         parser._pydifft_subparsers[name] = subparser
     return parser
+
+
 def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]

--- a/pydifftools/continuous.py
+++ b/pydifftools/continuous.py
@@ -12,7 +12,11 @@ import queue
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 from .command_registry import register_command
-from .browser_lifecycle import browser_window_is_alive, close_browser_window
+from .browser_lifecycle import (
+    browser_window_is_alive,
+    close_browser_window,
+    forward_search_in_browser,
+)
 
 FORWARD_SEARCH_HOST = "127.0.0.1"
 FORWARD_SEARCH_PORT = 51235
@@ -348,46 +352,10 @@ position
             fp.write(all_data)
 
     def forward_search(self, search_text):
-        # Use the browser's built-in window.find to locate the text.
+        # Reuse shared browser search behavior so cpb and qmdb stay in sync.
         if not search_text:
             return
-        found = self.firefox.execute_script(
-            """
-            var searchText = arguments[0];
-            if (!window.find) {
-                return false;
-            }
-            var didFind = window.find(searchText);
-            if (didFind && window.getSelection) {
-                var selection = window.getSelection();
-                if (selection.rangeCount > 0) {
-                    var rect = selection.getRangeAt(0).getBoundingClientRect();
-                    window.scrollBy(0, rect.top - window.innerHeight / 3);
-                }
-            }
-            return didFind;
-            """,
-            search_text,
-        )
-        if not found:
-            print("forward search did not find text:", search_text)
-        # Bring the browser window to the foreground in Linux window managers.
-        if os.name == "posix" and shutil.which("wmctrl"):
-            window_title = self.firefox.execute_script(
-                "return document.title;"
-            )
-            if window_title:
-                # Try common Chromium title forms used by desktop environments.
-                for title_candidate in [
-                    window_title,
-                    window_title + " - Google Chrome",
-                    window_title + " - Chromium",
-                    window_title + " - Chrome",
-                ]:
-                    subprocess.run(
-                        ["wmctrl", "-a", title_candidate],
-                        check=False,
-                    )
+        forward_search_in_browser(self.firefox, search_text)
 
 
 @register_command(

--- a/pydifftools/continuous.py
+++ b/pydifftools/continuous.py
@@ -355,7 +355,7 @@ position
         # Reuse shared browser search behavior so cpb and qmdb stay in sync.
         if not search_text:
             return
-        forward_search_in_browser(self.firefox, search_text)
+        forward_search_in_browser(self.chrome, search_text)
 
 @register_command(
     "continuous pandoc build.  Like latexmk, but for markdown!",

--- a/pydifftools/notebook/fast_build.py
+++ b/pydifftools/notebook/fast_build.py
@@ -537,9 +537,7 @@ def execute_code_blocks(blocks):
     for src, cells in blocks.items():
         if not cells:
             continue
-        cells = [
-            (*cell, False) if len(cell) == 2 else cell for cell in cells
-        ]
+        cells = [(*cell, False) if len(cell) == 2 else cell for cell in cells]
         codes = [c for c, _, _ in cells]
         md5s = [m for _, m, _ in cells]
         skip_flags = [flag for _, _, flag in cells]
@@ -682,7 +680,6 @@ def analyze_includes(render_files):
         if not current.exists():
             tree.setdefault(key, [])
             continue
-        root_dir = root_dirs.get(current, PROJECT_ROOT)
         includes: list[str] = []
         text = current.read_text()
         for _kind, inc in include_pattern.findall(text):
@@ -1251,7 +1248,8 @@ except ImportError:
 
 
 def notebook_marker_is_pending(src: str, html_text: str) -> bool:
-    """Return true when a rendered notebook marker has no substituted output."""
+    """Return true when a rendered notebook marker has no substituted
+    output."""
     if not html_text or "data-script" not in html_text or src not in html_text:
         return False
     if lxml_html is not None:
@@ -1685,8 +1683,7 @@ def build_all(webtex: bool = False, changed_paths=None, refresh_callback=None):
     if code_blocks:
         graph.print_tree_status("after notebook job submission", checksums)
         print(
-            f"Executing notebook blocks for {len(code_blocks)}"
-            " source files.",
+            f"Executing notebook blocks for {len(code_blocks)} source files.",
             flush=True,
         )
         notebook_executor = ThreadPoolExecutor(max_workers=1)
@@ -1954,7 +1951,8 @@ def watch_and_serve(no_browser: bool = False, webtex: bool = False):
                                 break
                             payload += chunk
                     if payload:
-                        # Reuse cpb forward-search behavior for qmdb browser windows.
+                        # Reuse cpb forward-search behavior for qmdb browser
+                        # windows.
                         try:
                             forward_search_in_browser(
                                 refresher.browser, payload.decode("utf-8")

--- a/pydifftools/notebook/fast_build.py
+++ b/pydifftools/notebook/fast_build.py
@@ -14,11 +14,13 @@ from pathlib import Path
 from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
 import threading
 import shutil
+import socket
 import yaml
 from pydifftools.command_registry import register_command
 from pydifftools.browser_lifecycle import (
     browser_window_is_alive,
     close_browser_window,
+    forward_search_in_browser,
 )
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers.polling import PollingObserver as Observer
@@ -751,6 +753,8 @@ PANDOC_TEMPLATE = Path("_template/pandoc_template.html").resolve()
 NAV_TEMPLATE = Path("_template/nav_template.html").resolve()
 MATHJAX_DIR = Path("_template/mathjax").resolve()
 PROJECT_ROOT = Path(".").resolve()
+QMDB_FORWARD_SEARCH_HOST = "127.0.0.1"
+QMDB_FORWARD_SEARCH_PORT = 51236
 
 
 def example_notebook_root():
@@ -1805,6 +1809,24 @@ def watch_and_serve(no_browser: bool = False, webtex: bool = False):
 
     observer = Observer()
 
+    # Listen on a dedicated qmdb socket so mfs can route searches to whichever
+    # browser session (cpb or qmdb) is already running.
+    forward_search_server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    forward_search_server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    forward_search_server.settimeout(0.25)
+    try:
+        forward_search_server.bind(
+            (QMDB_FORWARD_SEARCH_HOST, QMDB_FORWARD_SEARCH_PORT)
+        )
+        forward_search_server.listen(5)
+    except OSError as exc:
+        print(
+            "Could not start qmdb forward search socket "
+            f"on {QMDB_FORWARD_SEARCH_HOST}:{QMDB_FORWARD_SEARCH_PORT}: {exc}"
+        )
+        forward_search_server.close()
+        forward_search_server = None
+
     def rebuild(path):
         build_all(
             webtex=webtex,
@@ -1821,6 +1843,30 @@ def watch_and_serve(no_browser: bool = False, webtex: bool = False):
                 initial_future.result()
                 initial_executor.shutdown(wait=False)
                 initial_future = None
+            if forward_search_server is not None:
+                try:
+                    connection, _ = forward_search_server.accept()
+                except socket.timeout:
+                    connection = None
+                except OSError:
+                    connection = None
+                if connection is not None:
+                    with connection:
+                        payload = b""
+                        while True:
+                            chunk = connection.recv(4096)
+                            if not chunk:
+                                break
+                            payload += chunk
+                    if payload:
+                        # Reuse cpb forward-search behavior for qmdb browser windows.
+                        try:
+                            forward_search_in_browser(
+                                refresher.browser, payload.decode("utf-8")
+                            )
+                        except WebDriverException:
+                            close_browser_window(refresher.browser)
+                            refresher.browser = None
             if not no_browser and not refresher.is_alive():
                 break
             time.sleep(1)
@@ -1832,6 +1878,8 @@ def watch_and_serve(no_browser: bool = False, webtex: bool = False):
             initial_executor.shutdown(wait=False)
         observer.stop()
         observer.join()
+        if forward_search_server is not None:
+            forward_search_server.close()
         httpd.shutdown()
         httpd.server_close()
         if not no_browser and getattr(refresher, "browser", None):

--- a/pydifftools/notebook/fast_build.py
+++ b/pydifftools/notebook/fast_build.py
@@ -481,6 +481,12 @@ def load_bibliography_csl():
         bib = cfg["bibliography"]
     if "csl" in cfg:
         csl = cfg["csl"]
+    project = cfg.get("project", {})
+    if isinstance(project, dict):
+        if bib is None and "bibliography" in project:
+            bib = project["bibliography"]
+        if csl is None and "csl" in project:
+            csl = project["csl"]
     fmt = cfg.get("format", {})
     if isinstance(fmt, dict):
         for v in fmt.values():
@@ -1187,6 +1193,11 @@ def render_file(
 ):
     """Render ``src`` to ``dest`` using Pandoc with embedded resources."""
 
+    build_dir = Path(BUILD_DIR).resolve()
+    staged_src = Path(src)
+    if not staged_src.is_absolute():
+        staged_src = build_dir / staged_src
+    output_path = Path(dest).with_suffix(".html")
     template = BODY_TEMPLATE if fragment else PANDOC_TEMPLATE
     temp = os.path.relpath(
         DISPLAY_DIR / "mathjax" / "es5" / "tex-mml-chtml.js", dest.parent
@@ -1196,21 +1207,21 @@ def render_file(
     )
     args = [
         "pandoc",
-        src.name,
+        os.path.relpath(staged_src, build_dir),
         "--from",
         "markdown+raw_html",
         "--standalone",
         "--embed-resources",
         "--lua-filter",
-        os.path.relpath(BUILD_DIR / "obs.lua", dest.parent),
+        os.path.relpath(build_dir / "obs.lua", build_dir),
         "--filter",
         "pandoc-crossref",
         "--citeproc",
         math_arg,
         "--template",
-        os.path.relpath(template, dest.parent),
+        os.path.relpath(Path(template).resolve(), build_dir),
         "-o",
-        dest.with_suffix(".html").name,
+        os.path.relpath(output_path, build_dir),
     ]
     if bibliography:
         bib_path = Path(os.path.expanduser(bibliography))
@@ -1220,18 +1231,26 @@ def render_file(
             raise FileNotFoundError(
                 f"Bibliography file {bibliography} not found"
             )
-        args += ["--bibliography", os.path.relpath(bib_path, dest.parent)]
+        args += ["--bibliography", os.path.relpath(bib_path, build_dir)]
     if csl:
         csl_path = Path(os.path.expanduser(csl))
         if not csl_path.is_absolute():
             csl_path = PROJECT_ROOT / csl_path
         if not csl_path.exists():
             raise FileNotFoundError(f"CSL file {csl} not found")
-        args += ["--csl", os.path.relpath(csl_path, dest.parent)]
-    print(f"Running pandoc on {src}...", flush=True)
+        args += ["--csl", os.path.relpath(csl_path, build_dir)]
+    print("in directory",build_dir)
+    print(
+        f"Running pandoc on {src}..."
+        + "\n\t"
+        + " ".join(args)
+        + "\n\t"
+        + "." * 10,
+        flush=True,
+    )
     start = time.time()
     try:
-        subprocess.run(args, check=True, cwd=dest.parent, capture_output=True)
+        subprocess.run(args, check=True, cwd=build_dir, capture_output=True)
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"{e.stderr}\nwhen trying to run:{' '.join(args)}")
     duration = time.time() - start

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -380,9 +380,7 @@ def test_gd_build_entries_tracks_renamed_file(tmp_path):
         subprocess.run(
             ["git", "config", "user.email", "test@example.com"], check=True
         )
-        subprocess.run(
-            ["git", "config", "user.name", "Test User"], check=True
-        )
+        subprocess.run(["git", "config", "user.name", "Test User"], check=True)
         Path("old.txt").write_text("one\ntwo\nthree\n")
         subprocess.run(["git", "add", "old.txt"], check=True)
         subprocess.run(["git", "commit", "-q", "-m", "initial"], check=True)
@@ -414,9 +412,7 @@ def test_gd_pathspec_keeps_renamed_file_status(tmp_path):
         subprocess.run(
             ["git", "config", "user.email", "test@example.com"], check=True
         )
-        subprocess.run(
-            ["git", "config", "user.name", "Test User"], check=True
-        )
+        subprocess.run(["git", "config", "user.name", "Test User"], check=True)
         Path("old.txt").write_text("one\ntwo\nthree\n")
         subprocess.run(["git", "add", "old.txt"], check=True)
         subprocess.run(["git", "commit", "-q", "-m", "initial"], check=True)
@@ -600,7 +596,6 @@ def test_mfs_waits_up_to_20_seconds_for_socket(tmp_path):
         os.chdir(cwd)
 
 
-
 def test_mfs_uses_qmdb_socket_when_cpb_socket_missing(tmp_path):
     calls = {
         "connect": [],
@@ -695,6 +690,7 @@ def test_mfs_marker_regex_is_case_insensitive(tmp_path):
         assert calls["sendall"] == [b"Result before"]
     finally:
         os.chdir(cwd)
+
 
 def test_run_pandoc_adds_css_lua_and_js_files_from_markdown_directory(
     tmp_path, monkeypatch
@@ -812,7 +808,11 @@ def test_run_pandoc_does_not_overwrite_existing_comment_assets(
         '<?xml version="1.0" encoding="utf-8"?><style '
         'xmlns="http://purl.org/net/xbiblio/csl" version="1.0"></style>'
     )
-    for asset_name in ["comments.css", "comment_tags.lua", "comment_toggle.js"]:
+    for asset_name in [
+        "comments.css",
+        "comment_tags.lua",
+        "comment_toggle.js",
+    ]:
         (project_dir / asset_name).write_text(f"local override {asset_name}\n")
     html_file = tmp_path / "notes.html"
 
@@ -828,7 +828,11 @@ def test_run_pandoc_does_not_overwrite_existing_comment_assets(
 
     run_pandoc(str(markdown_file), str(html_file))
 
-    for asset_name in ["comments.css", "comment_tags.lua", "comment_toggle.js"]:
+    for asset_name in [
+        "comments.css",
+        "comment_tags.lua",
+        "comment_toggle.js",
+    ]:
         assert (project_dir / asset_name).read_text() == (
             f"local override {asset_name}\n"
         )
@@ -862,10 +866,14 @@ def test_comment_filter_mode_switches_to_margin_and_back(tmp_path):
 
     continuous._set_comment_filter_mode(str(project_dir), False)
     assert active_filter.read_text() == "normal filter\n"
-    assert continuous.MARGIN_COMMENTS_FILTER_MARKER in inactive_filter.read_text()
+    assert (
+        continuous.MARGIN_COMMENTS_FILTER_MARKER in inactive_filter.read_text()
+    )
 
 
-def test_comment_filter_mode_restores_repo_default_when_inactive_missing(tmp_path):
+def test_comment_filter_mode_restores_repo_default_when_inactive_missing(
+    tmp_path,
+):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
     active_filter = project_dir / "comment_tags.lua"
@@ -880,8 +888,13 @@ def test_comment_filter_mode_restores_repo_default_when_inactive_missing(tmp_pat
 
     assert active_filter.exists()
     assert inactive_filter.exists()
-    assert continuous.MARGIN_COMMENTS_FILTER_MARKER not in active_filter.read_text()
-    assert continuous.MARGIN_COMMENTS_FILTER_MARKER in inactive_filter.read_text()
+    assert (
+        continuous.MARGIN_COMMENTS_FILTER_MARKER
+        not in active_filter.read_text()
+    )
+    assert (
+        continuous.MARGIN_COMMENTS_FILTER_MARKER in inactive_filter.read_text()
+    )
 
 
 def test_margin_comment_filter_uses_overlay_style_for_inline_comments():
@@ -893,7 +906,7 @@ def test_margin_comment_filter_uses_overlay_style_for_inline_comments():
     assert "comment-inline-break-before" in margin_filter
     assert "comment-inline-break-after" in margin_filter
     assert "comment-pin comment-pin-block" in margin_filter
-    assert 'pandoc.RawInline(' in margin_filter
+    assert "pandoc.RawInline(" in margin_filter
 
 
 def test_run_pandoc_comment_tag_regression_end_to_end(tmp_path):
@@ -1053,7 +1066,7 @@ def test_comment_css_arrow_geometry_constants(tmp_path):
     assert "function cssVariableLengthPx" in js_content
     assert "SELECTOR_INLINE" in js_content
     assert "useMobileFlow" in js_content
-    assert 'comment-margin-left' in js_content
+    assert "comment-margin-left" in js_content
     assert "bubble.style.transform" in js_content
     assert "left = ax + gap + overlayRightShift" in js_content
     assert "const top = ay - overlayRise" in js_content

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -283,13 +283,109 @@ def test_mfs_waits_up_to_20_seconds_for_socket(tmp_path):
                         assert False, "Expected mfs to raise RuntimeError"
                     except RuntimeError as exc:
                         assert "within 20 seconds" in str(exc)
-        # one initial connect plus 80 retries gives a full 20-second wait
-        # window
-        assert calls["connect"] == 81
+        # We try cpb and qmdb sockets each time: one initial pass plus
+        # 80 retry passes gives 162 connection attempts total.
+        assert calls["connect"] == 162
         assert calls["sleep"] == 80
     finally:
         os.chdir(cwd)
 
+
+
+def test_mfs_uses_qmdb_socket_when_cpb_socket_missing(tmp_path):
+    calls = {
+        "connect": [],
+        "sendall": [],
+        "fork": 0,
+    }
+
+    class FakeSocket:
+        def __init__(self, *args, **kwargs):
+            return
+
+        def connect(self, address):
+            calls["connect"].append(address)
+            # First (cpb) socket fails, second (qmdb) socket succeeds.
+            if len(calls["connect"]) == 1:
+                raise OSError("cpb socket missing")
+
+        def sendall(self, payload):
+            calls["sendall"].append(payload)
+
+        def close(self):
+            return
+
+    def fake_fork():
+        calls["fork"] += 1
+        return 123
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        with patch("pydifftools.command_line.socket.socket", FakeSocket):
+            with patch("pydifftools.command_line.os.fork", fake_fork):
+                mfs("needle")
+        assert calls["fork"] == 0
+        assert len(calls["connect"]) == 2
+        assert calls["sendall"] == [b"needle"]
+    finally:
+        os.chdir(cwd)
+
+
+def test_mfs_strips_markdown_markup_before_search(tmp_path):
+    calls = {
+        "sendall": [],
+    }
+
+    class FakeSocket:
+        def __init__(self, *args, **kwargs):
+            return
+
+        def connect(self, _address):
+            return
+
+        def sendall(self, payload):
+            calls["sendall"].append(payload)
+
+        def close(self):
+            return
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        with patch("pydifftools.command_line.socket.socket", FakeSocket):
+            mfs("**Result** near @fig:overview [@smith2024]")
+        assert calls["sendall"] == [b"Result near"]
+    finally:
+        os.chdir(cwd)
+
+
+def test_mfs_marker_regex_is_case_insensitive(tmp_path):
+    calls = {
+        "sendall": [],
+    }
+
+    class FakeSocket:
+        def __init__(self, *args, **kwargs):
+            return
+
+        def connect(self, _address):
+            return
+
+        def sendall(self, payload):
+            calls["sendall"].append(payload)
+
+        def close(self):
+            return
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        with patch("pydifftools.command_line.socket.socket", FakeSocket):
+            mfs("Result before @FIG:overview should truncate")
+        assert calls["sendall"] == [b"Result before"]
+    finally:
+        os.chdir(cwd)
 
 def test_run_pandoc_adds_css_lua_and_js_files_from_markdown_directory(
     tmp_path, monkeypatch

--- a/tests/notebook/test_fast_build.py
+++ b/tests/notebook/test_fast_build.py
@@ -15,14 +15,33 @@ def fb(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("PYDIFFTOOLS_FAKE_MATHJAX", "1")
     fast_build.qmdinit(tmp_path, force=True)
+    original_load_bibliography_csl = fast_build.load_bibliography_csl
     fast_build.load_bibliography_csl = lambda: (None, None)
     original_build = fast_build.BUILD_DIR
     original_display = fast_build.DISPLAY_DIR
     try:
         yield fast_build
     finally:
+        fast_build.load_bibliography_csl = original_load_bibliography_csl
         fast_build.BUILD_DIR = original_build
         fast_build.DISPLAY_DIR = original_display
+
+
+def test_load_bibliography_csl_reads_project_block(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    Path("_quarto.yml").write_text(
+        "project:\n"
+        "  type: website\n"
+        "  bibliography: references.bib\n"
+        '  csl: "emails/superscript_ref_short.csl"\n'
+        "  render:\n"
+        "    - notebook260417.qmd\n"
+    )
+
+    assert fast_build.load_bibliography_csl() == (
+        "references.bib",
+        "emails/superscript_ref_short.csl",
+    )
 
 
 def test_analyze_includes_map(fb):
@@ -118,6 +137,48 @@ def test_render_file_webtex(fb, tmp_path, monkeypatch):
     fb.render_file(src, dest, fragment=False, webtex=True)
     assert "--webtex" in called["args"]
     assert not any(a.startswith("--mathjax") for a in called["args"])
+
+
+def test_render_file_paths_are_rooted_at_build_dir(fb, monkeypatch):
+    (fb.PROJECT_ROOT / "references.bib").write_text(
+        "@misc{dummy, title={Dummy}}\n"
+    )
+    csl_dir = fb.PROJECT_ROOT / "emails"
+    csl_dir.mkdir()
+    (csl_dir / "superscript_ref_short.csl").write_text(
+        '<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0"></style>'
+    )
+    nested = fb.BUILD_DIR / "project1" / "subproject1"
+    nested.mkdir(parents=True, exist_ok=True)
+    (fb.BUILD_DIR / "obs.lua").write_text("")
+    (nested / "tasks.qmd").write_text("# Nested\n")
+    called = {}
+
+    def fake_run(cmd, check, cwd=None, capture_output=False):
+        called["args"] = cmd
+        called["cwd"] = cwd
+
+    monkeypatch.setattr(fb.subprocess, "run", fake_run)
+    fb.render_file(
+        Path("project1/subproject1/tasks.qmd"),
+        nested / "tasks.qmd",
+        fragment=True,
+        bibliography="references.bib",
+        csl="emails/superscript_ref_short.csl",
+        webtex=True,
+    )
+
+    args = called["args"]
+    assert called["cwd"] == fb.BUILD_DIR.resolve()
+    assert args[1] == "project1/subproject1/tasks.qmd"
+    assert args[args.index("--lua-filter") + 1] == "obs.lua"
+    assert args[args.index("--template") + 1] == "../_template/body-only.html"
+    assert args[args.index("--bibliography") + 1] == "../references.bib"
+    assert (
+        args[args.index("--csl") + 1]
+        == "../emails/superscript_ref_short.csl"
+    )
+    assert args[args.index("-o") + 1] == "project1/subproject1/tasks.html"
 
 
 def test_postprocess_nested_includes(fb, tmp_path, monkeypatch):

--- a/tests/notebook/test_fast_build.py
+++ b/tests/notebook/test_fast_build.py
@@ -175,8 +175,7 @@ def test_render_file_paths_are_rooted_at_build_dir(fb, monkeypatch):
     assert args[args.index("--template") + 1] == "../_template/body-only.html"
     assert args[args.index("--bibliography") + 1] == "../references.bib"
     assert (
-        args[args.index("--csl") + 1]
-        == "../emails/superscript_ref_short.csl"
+        args[args.index("--csl") + 1] == "../emails/superscript_ref_short.csl"
     )
     assert args[args.index("-o") + 1] == "project1/subproject1/tasks.html"
 
@@ -388,16 +387,13 @@ print('hello')
     assert fb.RenderNotebook.count_code_blocks(text) == 1
 
 
-# TODO ☐: I really disapprove of calling things "monkeypatch" without further explanation
+# TODO ☐: I really disapprove of calling things "monkeypatch" without further
+#         explanation
 def test_noexec_magic_marks_block_without_execution(fb, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     src = Path("doc.qmd")
     src.write_text(
-        "# noexec test\n\n"
-        "```python\n"
-        "%noexec\n"
-        "print('skip')\n"
-        "```\n"
+        "# noexec test\n\n" "```python\n" "%noexec\n" "print('skip')\n" "```\n"
     )
     fb.PROJECT_ROOT = tmp_path
     fb.BUILD_DIR = tmp_path / "_build"


### PR DESCRIPTION
### Motivation
- Provide a single, reusable browser forward-search implementation so multiple watch servers (cpb and qmdb) behave the same when jumping to text in the browser.
- Allow the `mfs` command to target whichever forward-search listener is already running and to match rendered Markdown text more reliably.
- Expose a dedicated socket for the minimal Pandoc build (`qmdb`) so `mfs` can route searches to either server.

### Description
- Added `forward_search_in_browser` to `pydifftools/browser_lifecycle.py` which runs browser-side `window.find`, recenters the selection, and optionally uses `wmctrl` to raise the window on X11.
- Replaced duplicated inlined JS search code with calls to `forward_search_in_browser` from `pydifftools/continuous.py` and `pydifftools/notebook/fast_build.py` to unify behavior.
- Extended `pydifftools/command_line.py` `mfs` command to normalize Markdown markup before searching, attempt both cpb and qmdb socket addresses, and retry discovery across both sockets before launching a new `cpb` process.
- Added a dedicated `qmdb` forward-search socket in `pydifftools/notebook/fast_build.py` (`QMDB_FORWARD_SEARCH_HOST`/`QMDB_FORWARD_SEARCH_PORT`) and dispatch incoming payloads to the browser via `forward_search_in_browser`.
- Updated imports and constants to expose the new qmdb socket addresses to the CLI, and cleaned up socket connection/retry logic in `mfs`.
- Added and adjusted unit tests in `tests/cli/test_commands.py` to reflect new socket behavior and markdown-normalization: updated `test_mfs_waits_up_to_20_seconds_for_socket` expected connection attempts and added `test_mfs_uses_qmdb_socket_when_cpb_socket_missing`, `test_mfs_strips_markdown_markup_before_search`, and `test_mfs_marker_regex_is_case_insensitive`.

### Testing
- Ran the `tests/cli/test_commands.py` unit tests (including newly added tests) under `pytest`, and they passed.
- Ran the repository test suite with `pytest` to validate integration of forward-search changes, and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69c279448bc0832bb2fb2c23e6b217d0)